### PR TITLE
Implement chat message token tracking

### DIFF
--- a/core/src/main/kotlin/io/qent/sona/core/ChatRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatRepository.kt
@@ -1,0 +1,45 @@
+package io.qent.sona.core
+
+import dev.langchain4j.data.message.ChatMessage
+
+/**
+ * Repository for storing user chats and messages.
+ */
+interface ChatRepository {
+    /** Create a new chat and return its id. */
+    suspend fun createChat(): String
+
+    /**
+     * Append a message to a chat. The [model] name and token usage
+     * are optional and normally provided for AI messages.
+     */
+    suspend fun addMessage(
+        chatId: String,
+        message: ChatMessage,
+        model: String? = null,
+        inputTokens: Int = 0,
+        outputTokens: Int = 0,
+    )
+
+    /** Load all messages for a chat. */
+    suspend fun loadMessages(chatId: String): List<StoredChatMessage>
+
+    /** List all chats with their first message snippet. */
+    suspend fun listChats(): List<ChatSummary>
+
+    /** Delete chat with all messages. */
+    suspend fun deleteChat(chatId: String)
+}
+
+data class StoredChatMessage(
+    val message: ChatMessage,
+    val model: String? = null,
+    val inputTokens: Int = 0,
+    val outputTokens: Int = 0,
+)
+
+data class ChatSummary(
+    val id: String,
+    val firstMessage: String,
+    val createdAt: Long,
+)

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -2,10 +2,21 @@ package io.qent.sona.core
 
 import dev.langchain4j.data.message.ChatMessage
 
-data class State(
-    val messages: List<ChatMessage> = emptyList(),
-    val outgoingTokens: Int = 0,
-    val incomingTokens: Int = 0,
-    val isSending: Boolean = false,
-    val onSendMessage: (String) -> Unit = {},
-)
+sealed class State {
+    data class ChatState(
+        val messages: List<ChatMessage> = emptyList(),
+        val outgoingTokens: Int = 0,
+        val incomingTokens: Int = 0,
+        val isSending: Boolean = false,
+        val onSendMessage: (String) -> Unit = {},
+        val onNewChat: () -> Unit = {},
+        val onOpenHistory: () -> Unit = {},
+    ) : State()
+
+    data class ChatListState(
+        val chats: List<ChatSummary> = emptyList(),
+        val onOpenChat: (String) -> Unit = {},
+        val onDeleteChat: (String) -> Unit = {},
+        val onNewChat: () -> Unit = {},
+    ) : State()
+}

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -14,49 +14,116 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class StateProvider(
-    private val repository: SettingsRepository,
+    private val settingsRepository: SettingsRepository,
+    private val chatRepository: ChatRepository,
     private val modelFactory: suspend (Settings) -> ChatModel,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 ) {
-    private val messages = mutableListOf<ChatMessage>()
+    private var currentChatId: String? = null
+    private var messages = mutableListOf<StoredChatMessage>()
     private var outgoing = 0
     private var incoming = 0
     private var sending = false
 
-    private val _state = MutableStateFlow(createState())
+    private val _state = MutableStateFlow<State>(State.ChatState())
     val state: StateFlow<State> = _state.asStateFlow()
 
-    private fun createState() = State(
-        messages = messages.toList(),
+    init {
+        scope.launch { loadInitialChat() }
+    }
+
+    private suspend fun loadInitialChat() {
+        val chats = chatRepository.listChats()
+        currentChatId = chats.firstOrNull()?.id ?: chatRepository.createChat()
+        messages = chatRepository.loadMessages(currentChatId!!).toMutableList()
+        recalcTokens()
+        emitChatState()
+    }
+
+    private fun createChatState() = State.ChatState(
+        messages = messages.map { it.message },
         outgoingTokens = outgoing,
         incomingTokens = incoming,
         isSending = sending,
         onSendMessage = { text -> scope.launch { send(text) } },
+        onNewChat = { scope.launch { newChat() } },
+        onOpenHistory = { scope.launch { showHistory() } },
     )
 
-    private fun emit() {
-        _state.value = createState()
+    private fun createListState(chats: List<ChatSummary>) = State.ChatListState(
+        chats = chats,
+        onOpenChat = { id -> scope.launch { openChat(id) } },
+        onDeleteChat = { id -> scope.launch { deleteChat(id) } },
+        onNewChat = { scope.launch { newChat() } },
+    )
+
+    private fun emitChatState() {
+        _state.value = createChatState()
+    }
+
+    private suspend fun showHistory() {
+        val chats = chatRepository.listChats()
+        _state.value = createListState(chats)
+    }
+
+    private suspend fun newChat() {
+        currentChatId = chatRepository.createChat()
+        messages.clear()
+        outgoing = 0
+        incoming = 0
+        emitChatState()
+    }
+
+    private suspend fun openChat(id: String) {
+        currentChatId = id
+        messages = chatRepository.loadMessages(id).toMutableList()
+        recalcTokens()
+        emitChatState()
+    }
+
+    private suspend fun deleteChat(id: String) {
+        chatRepository.deleteChat(id)
+        showHistory()
+    }
+
+    private fun recalcTokens() {
+        outgoing = messages.sumOf { it.inputTokens }
+        incoming = messages.sumOf { it.outputTokens }
     }
 
     private suspend fun send(text: String) {
+        val chatId = currentChatId ?: return
         if (sending) return
         sending = true
-        messages += UserMessage.from(text)
-        emit()
+        val userMsg = UserMessage.from(text)
+        messages += StoredChatMessage(userMsg)
+        chatRepository.addMessage(chatId, userMsg, null, 0, 0)
+        emitChatState()
         try {
-            val settings = repository.load()
+            val settings = settingsRepository.load()
             val model = modelFactory(settings)
-            val response: ChatResponse = model.chat(messages)
+            val response: ChatResponse = model.chat(messages.map { it.message })
             val aiMessage = response.aiMessage()
             val usage: TokenUsage? = response.tokenUsage()
-            outgoing += usage?.inputTokenCount() ?: 0
-            incoming += usage?.outputTokenCount() ?: 0
-            messages += aiMessage
+            val out = usage?.inputTokenCount() ?: 0
+            val inn = usage?.outputTokenCount() ?: 0
+            outgoing += out
+            incoming += inn
+            val stored = StoredChatMessage(
+                aiMessage,
+                model = settings.model,
+                inputTokens = out,
+                outputTokens = inn,
+            )
+            messages += stored
+            chatRepository.addMessage(chatId, aiMessage, settings.model, out, inn)
         } catch (e: Exception) {
-            messages += AiMessage.from("Error: ${e.message}")
+            val err = AiMessage.from("Error: ${e.message}")
+            messages += StoredChatMessage(err)
+            chatRepository.addMessage(chatId, err, null, 0, 0)
         } finally {
             sending = false
-            emit()
+            emitChatState()
         }
     }
 }

--- a/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
+++ b/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
@@ -9,15 +9,17 @@ import com.intellij.ui.content.ContentFactory
 import dev.langchain4j.model.anthropic.AnthropicChatModel
 import io.qent.sona.core.StateProvider
 import io.qent.sona.settings.PluginSettingsRepository
+import io.qent.sona.chat.PluginChatRepository
 import io.qent.sona.ui.PluginPanel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 
 class PluginToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val repository = service<PluginSettingsRepository>()
+        val settingsRepository = service<PluginSettingsRepository>()
+        val chatRepository = service<PluginChatRepository>()
         val scope = CoroutineScope(Dispatchers.Default)
-        val logic = StateProvider(repository, modelFactory = { settings ->
+        val logic = StateProvider(settingsRepository, chatRepository, modelFactory = { settings ->
             AnthropicChatModel.builder()
                 .apiKey(settings.apiKey)
                 .baseUrl(settings.apiEndpoint)

--- a/src/main/kotlin/io/qent/sona/chat/PluginChatRepository.kt
+++ b/src/main/kotlin/io/qent/sona/chat/PluginChatRepository.kt
@@ -1,0 +1,89 @@
+package io.qent.sona.chat
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import io.qent.sona.core.ChatRepository
+import io.qent.sona.core.ChatSummary
+import io.qent.sona.core.StoredChatMessage
+import dev.langchain4j.data.message.ChatMessage
+import dev.langchain4j.data.message.ChatMessageDeserializer
+import dev.langchain4j.data.message.ChatMessageSerializer
+import java.util.UUID
+
+@Service
+@State(name = "PluginChatRepository", storages = [Storage("chat_history.xml")])
+class PluginChatRepository : ChatRepository, PersistentStateComponent<PluginChatRepository.ChatsState> {
+
+    data class StoredMessage(
+        var json: String = "",
+        var model: String? = null,
+        var inputTokens: Int = 0,
+        var outputTokens: Int = 0,
+        var timestamp: Long = 0L,
+    )
+
+    data class StoredChat(
+        var id: String = UUID.randomUUID().toString(),
+        var createdAt: Long = System.currentTimeMillis(),
+        var messages: MutableList<StoredMessage> = mutableListOf(),
+    )
+
+    data class ChatsState(
+        var chats: MutableList<StoredChat> = mutableListOf(),
+    )
+
+    private var state = ChatsState()
+
+    override fun getState() = state
+
+    override fun loadState(state: ChatsState) {
+        this.state = state
+    }
+
+    private fun findChat(id: String) = state.chats.first { it.id == id }
+
+    private fun StoredMessage.toStoredChatMessage(): StoredChatMessage {
+        val msg = ChatMessageDeserializer.messageFromJson(json)
+        return StoredChatMessage(
+            message = msg,
+            model = model,
+            inputTokens = inputTokens,
+            outputTokens = outputTokens,
+        )
+    }
+
+    override suspend fun createChat(): String {
+        val chat = StoredChat()
+        state.chats.add(chat)
+        return chat.id
+    }
+
+    override suspend fun addMessage(chatId: String, message: ChatMessage, model: String?, inputTokens: Int, outputTokens: Int) {
+        val stored = StoredMessage(
+            json = ChatMessageSerializer.messageToJson(message),
+            model = model,
+            inputTokens = inputTokens,
+            outputTokens = outputTokens,
+            timestamp = System.currentTimeMillis(),
+        )
+        findChat(chatId).messages.add(stored)
+    }
+
+    override suspend fun loadMessages(chatId: String): List<StoredChatMessage> {
+        return findChat(chatId).messages.map { it.toStoredChatMessage() }
+    }
+
+    override suspend fun listChats(): List<ChatSummary> {
+        return state.chats.sortedBy { it.createdAt }.map { chat ->
+            val firstMsg = chat.messages.firstOrNull()?.let { ChatMessageDeserializer.messageFromJson(it.json) }
+            val first = firstMsg?.toString() ?: ""
+            ChatSummary(chat.id, first.take(100), chat.createdAt)
+        }
+    }
+
+    override suspend fun deleteChat(chatId: String) {
+        state.chats.removeIf { it.id == chatId }
+    }
+}

--- a/src/main/kotlin/io/qent/sona/ui/PluginPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/PluginPanel.kt
@@ -22,7 +22,11 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.dp
 import io.qent.sona.core.State
+import io.qent.sona.core.State.ChatState
+import io.qent.sona.core.State.ChatListState
 import io.qent.sona.core.StateProvider
+import java.text.SimpleDateFormat
+import java.util.Date
 import org.jetbrains.jewel.bridge.JewelComposePanel
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
@@ -33,23 +37,35 @@ class PluginPanel(private val pluginStateProvider: StateProvider) {
 
     @Composable
     private fun Ui() {
-        val chatState = pluginStateProvider.state.collectAsState()
-        Column(Modifier.Companion.fillMaxSize()) {
-            Header(chatState.value)
-            Messages(chatState.value, modifier = Modifier.Companion.weight(1f))
-            Input(chatState.value)
+        val state = pluginStateProvider.state.collectAsState()
+        when (val s = state.value) {
+            is ChatState -> ChatScreen(s)
+            is ChatListState -> ChatListScreen(s)
         }
     }
 
     @Composable
-    private fun Header(state: State) {
-        Row(Modifier.Companion.fillMaxWidth().padding(8.dp)) {
+    private fun ChatScreen(state: ChatState) {
+        Column(Modifier.fillMaxSize()) {
+            Header(state)
+            Messages(state, modifier = Modifier.weight(1f))
+            Input(state)
+        }
+    }
+
+    @Composable
+    private fun Header(state: ChatState) {
+        Row(Modifier.fillMaxWidth().padding(8.dp)) {
+            ActionButton(onClick = state.onNewChat) { Text("+") }
+            Spacer(Modifier.width(8.dp))
+            ActionButton(onClick = state.onOpenHistory) { Text("History") }
+            Spacer(Modifier.width(8.dp))
             Text("Out: ${state.outgoingTokens}  In: ${state.incomingTokens}")
         }
     }
 
     @Composable
-    private fun Messages(state: State, modifier: Modifier = Modifier.Companion) {
+    private fun Messages(state: ChatState, modifier: Modifier = Modifier) {
         val scroll = rememberScrollState()
         Column(modifier.fillMaxWidth().verticalScroll(scroll).padding(8.dp)) {
             state.messages.forEach { msg ->
@@ -60,7 +76,7 @@ class PluginPanel(private val pluginStateProvider: StateProvider) {
     }
 
     @Composable
-    private fun Input(state: State) {
+    private fun Input(state: ChatState) {
         val text = rememberTextFieldState()
         fun sendMessage() {
             if (text.text.isNotBlank()) {
@@ -87,6 +103,31 @@ class PluginPanel(private val pluginStateProvider: StateProvider) {
                 onClick = { sendMessage() },
                 enabled = !state.isSending
             ) { Text("Send") }
+        }
+    }
+
+    @Composable
+    private fun ChatListScreen(state: ChatListState) {
+        Column(Modifier.fillMaxSize()) {
+            Row(Modifier.fillMaxWidth().padding(8.dp)) {
+                ActionButton(onClick = state.onNewChat) { Text("+") }
+            }
+            val scroll = rememberScrollState()
+            Column(Modifier.fillMaxWidth().weight(1f).verticalScroll(scroll).padding(8.dp)) {
+                state.chats.forEach { chat ->
+                    Row(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                        ActionButton(onClick = { state.onOpenChat(chat.id) }) {
+                            Column(Modifier.weight(1f)) {
+                                Text(chat.firstMessage)
+                                val date = SimpleDateFormat("yyyy-MM-dd HH:mm").format(Date(chat.createdAt))
+                                Text(date)
+                            }
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        ActionButton(onClick = { state.onDeleteChat(chat.id) }) { Text("\uD83D\uDDD1") }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,7 @@
                 anchor="right"/>
 
         <applicationService serviceImplementation="io.qent.sona.settings.PluginSettingsRepository"/>
+        <applicationService serviceImplementation="io.qent.sona.chat.PluginChatRepository"/>
 
         <applicationConfigurable
                 id="SonaChatSettings"


### PR DESCRIPTION
## Summary
- extend `ChatRepository` to save model and token usage with each message
- track tokens in `StateProvider` and persist them in `PluginChatRepository`
- serialize all message types using `ChatMessageSerializer`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688b72e8c9bc832080d2f810456f0132