### PR TITLE
Add roles editing state and system prompt

### DIFF
--- a/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
@@ -29,6 +29,9 @@ class ChatFlow(
 
     private val innerStateFlow = MutableStateFlow(Chat("", TokenUsage(0, 0)))
 
+    val chatId: String
+        get() = innerStateFlow.value.chatId
+
     suspend fun loadChat(chatId: String) {
         var outputTokens = 0
         var inputTokens = 0

--- a/core/src/main/kotlin/io/qent/sona/core/RolesRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/RolesRepository.kt
@@ -1,0 +1,6 @@
+package io.qent.sona.core
+
+interface RolesRepository {
+    suspend fun load(): String
+    suspend fun save(text: String)
+}

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -5,6 +5,7 @@ import dev.langchain4j.data.message.ChatMessage
 sealed class State {
     abstract val onNewChat: () -> Unit
     abstract val onOpenHistory: () -> Unit
+    abstract val onOpenRoles: () -> Unit
 
     data class ChatState(
         val messages: List<ChatMessage> = emptyList(),
@@ -14,6 +15,7 @@ sealed class State {
         val onSendMessage: (String) -> Unit = {},
         override val onNewChat: () -> Unit = {},
         override val onOpenHistory: () -> Unit = {},
+        override val onOpenRoles: () -> Unit = {},
     ) : State()
 
     data class ChatListState(
@@ -21,7 +23,17 @@ sealed class State {
         val onOpenChat: (String) -> Unit = {},
         val onDeleteChat: (String) -> Unit = {},
         override val onNewChat: () -> Unit = {},
+        override val onOpenRoles: () -> Unit = {},
     ) : State() {
         override val onOpenHistory = { }
+    }
+
+    data class RolesState(
+        val text: String = "",
+        val onSave: (String) -> Unit = {},
+        override val onNewChat: () -> Unit = {},
+    ) : State() {
+        override val onOpenHistory = { }
+        override val onOpenRoles = { }
     }
 }

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -10,6 +10,7 @@ import io.qent.sona.core.StateProvider
 import io.qent.sona.core.Tools
 import io.qent.sona.repositories.PluginChatRepository
 import io.qent.sona.repositories.PluginSettingsRepository
+import io.qent.sona.repositories.PluginRolesRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.FlowCollector
@@ -20,9 +21,13 @@ class PluginStateFlow(private val project: Project) : StateFlow<State> {
 
     private val settingsRepository = service<PluginSettingsRepository>()
     private val chatRepository = service<PluginChatRepository>()
+    private val rolesRepository = service<PluginRolesRepository>()
     private val scope = CoroutineScope(Dispatchers.Default)
     private val stateProvider = StateProvider(
-        settingsRepository, chatRepository, modelFactory = { settings ->
+        settingsRepository,
+        chatRepository,
+        rolesRepository,
+        modelFactory = { settings ->
         AnthropicChatModel.builder()
             .apiKey(settings.apiKey)
             .baseUrl(settings.apiEndpoint)

--- a/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
+++ b/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
@@ -20,7 +20,8 @@ class PluginToolWindowFactory : ToolWindowFactory, DumbAware {
 
         toolWindow.setTitleActions(listOf(
             ActionManager.getInstance().getAction("CreateNewChatAction"),
-            ActionManager.getInstance().getAction("OpenHistoryAction")
+            ActionManager.getInstance().getAction("OpenHistoryAction"),
+            ActionManager.getInstance().getAction("OpenRolesAction")
         ))
     }
 }

--- a/src/main/kotlin/io/qent/sona/actions/OpenRolesAction.kt
+++ b/src/main/kotlin/io/qent/sona/actions/OpenRolesAction.kt
@@ -1,0 +1,13 @@
+package io.qent.sona.actions
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
+import io.qent.sona.PluginStateFlow
+
+class OpenRolesAction : AnAction("Role", "Edit system message", AllIcons.General.User) {
+    override fun actionPerformed(e: AnActionEvent) {
+        e.project?.service<PluginStateFlow>()?.value?.onOpenRoles?.invoke()
+    }
+}

--- a/src/main/kotlin/io/qent/sona/repositories/PluginRolesRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginRolesRepository.kt
@@ -1,0 +1,27 @@
+package io.qent.sona.repositories
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import io.qent.sona.core.RolesRepository
+
+@Service
+@State(name = "PluginRoles", storages = [Storage("roles.xml")])
+class PluginRolesRepository : RolesRepository, PersistentStateComponent<PluginRolesRepository.RolesState> {
+    data class RolesState(var text: String = "You are an IDE assistant plugin.")
+
+    private var state = RolesState()
+
+    override fun getState() = state
+
+    override fun loadState(state: RolesState) {
+        this.state = state
+    }
+
+    override suspend fun load(): String = state.text
+
+    override suspend fun save(text: String) {
+        state = state.copy(text = text)
+    }
+}

--- a/src/main/kotlin/io/qent/sona/ui/PluginPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/PluginPanel.kt
@@ -25,6 +25,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import io.qent.sona.core.State.ChatState
 import io.qent.sona.core.State.ChatListState
+import io.qent.sona.core.State.RolesState
 import io.qent.sona.PluginStateFlow
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -38,6 +39,7 @@ fun Ui(project: Project) {
     when (val s = state.value) {
         is ChatState -> ChatScreen(s)
         is ChatListState -> ChatListScreen(s)
+        is RolesState -> RolesScreen(s)
     }
 }
 
@@ -115,6 +117,17 @@ private fun ChatListScreen(state: ChatListState) {
                 Spacer(Modifier.width(8.dp))
                 ActionButton(onClick = { state.onDeleteChat(chat.id) }) { Text("\uD83D\uDDD1") }
             }
+        }
+    }
+}
+@Composable
+private fun RolesScreen(state: RolesState) {
+    val textState = rememberTextFieldState(state.text)
+    Column(Modifier.fillMaxSize().padding(8.dp)) {
+        TextField(textState, Modifier.weight(1f).fillMaxWidth())
+        Spacer(Modifier.height(8.dp))
+        ActionButton(onClick = { state.onSave(textState.text.toString()) }, modifier = Modifier.fillMaxWidth()) {
+            Text("Save")
         }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,12 @@
                 text="History"
                 description="Open history"
                 icon="AllIcons.General.History"/>
+
+        <action id="OpenRolesAction"
+                class="io.qent.sona.actions.OpenRolesAction"
+                text="Role"
+                description="Edit system message"
+                icon="AllIcons.General.User"/>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">
@@ -37,6 +43,7 @@
 
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginSettingsRepository"/>
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginChatRepository"/>
+        <applicationService serviceImplementation="io.qent.sona.repositories.PluginRolesRepository"/>
 
         <applicationConfigurable
                 id="SonaChatSettings"


### PR DESCRIPTION
## Summary
- implement `RolesRepository` in core and plugin implementation
- introduce new `RolesState` for editing the system prompt
- store system prompt in chat repository when creating a chat
- filter system messages from chat UI
- add action and tool window button to open roles editor

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688c4e5e1db88320ad6287ae16520b7e