### PR TITLE
Improve docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,22 @@
 - The logic module must not depend on IntelliJ SDK; only the UI module may use it.
 - Use Compose for all UI components.
 - Settings are stored using a repository interface in the logic module with an IntelliJ implementation in the UI module.
+- Chat history is persisted via a repository implementation (`PluginChatRepository`) that stores chats across IDE sessions.
 - Run `./gradlew build` before committing any changes.
+- After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
+
+## Current structure
+
+- **core module** – contains `ChatFlow` and `StateProvider`. `ChatFlow` is a
+  `MutableStateFlow` based `Flow` that manages the conversation with the model
+  and keeps track of token usage. `StateProvider` maps that flow to a higher
+  level `State` used by the UI.
+- **Plugin module** – provides IntelliJ implementations of the repositories,
+  the Compose UI and `PluginStateFlow`, a project service exposing
+  `StateFlow<State>` from `StateProvider`.
+
+`Tools` are injected into `ChatFlow` through an interface so that IDE specific
+helpers can be implemented in the plugin module.
+
+Whenever you extend the logic make sure the flow of state remains unidirectional
+and that the core module stays free from IntelliJ SDK imports.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,79 @@
 # sona
 
-Chat with Anthropic models directly from a side panel in your IDE. The chat history lives only for the current IDE session. Configure API token, endpoint and model in the settings.
+Chat with Anthropic models directly from a side panel in your IDE. The chat
+history is persisted in IDE storage so it survives restarts. Configure API
+token, endpoint and model in the settings.
 
 <!-- Plugin description -->
-Chat with an Anthropic language model right inside your IDE. The chat history is stored only for the current session.
+Chat with an Anthropic language model right inside your IDE. The chat history is stored persistently so you can resume conversations after restarting the IDE.
 <!-- Plugin description end -->
 
 ## Installation
 Use the IDE plugin manager or download the plugin from releases.
+
+## Architecture Overview
+
+The project is split into two modules:
+
+* `core` – contains all domain logic and is free from IntelliJ
+  dependencies. It exposes a Flow‑based API used by the UI module.
+* plugin module – implements the IntelliJ part and hosts the Compose UI.
+
+### Core module
+
+The `core` module defines a small MVI style state container. The main
+entry point is `ChatFlow`, a `Flow<Chat>` backed by a `MutableStateFlow`.
+It orchestrates message exchange with the language model and exposes the
+current conversation state:
+
+```
+data class Chat(
+    val chatId: String,
+    val tokenUsage: TokenUsage,
+    val messages: List<ChatRepositoryMessage> = emptyList(),
+    val requestInProgress: Boolean = false
+)
+```
+
+`StateProvider` consumes `ChatFlow` and maps it to a higher level
+`State` model used by the UI. Both `ChatFlow` and `StateProvider`
+operate purely on Kotlin flows without any IntelliJ types.
+
+Repositories for settings and chat history are declared as interfaces in
+`core` so that the UI module can provide IDE specific implementations.
+
+### Plugin module
+
+`PluginStateFlow` is registered as a project service and bridges the
+`StateProvider` to IntelliJ. It also supplies implementations of the
+repositories and of helper tools such as retrieving the currently focused
+file contents. The Compose‑based UI in `ui/PluginPanel.kt` collects the
+`StateFlow` from `PluginStateFlow` to render either the chat screen or the
+chat history list.
+
+Chat history is persisted via `PluginChatRepository`, which uses IntelliJ's
+`PersistentStateComponent` to store chats in `chat_history.xml`.
+
+The UI is written entirely with Compose (via Jewel Compose) in accordance
+with the development guidelines.
+
+### Flow usage
+
+All state propagation relies on Kotlin `Flow`/`StateFlow`:
+
+* `ChatFlow` implements `Flow<Chat>` and exposes conversation updates.
+* `StateProvider` provides a `StateFlow<State>` for the UI.
+* `PluginStateFlow` exposes the same `StateFlow` as a project level
+  service.
+
+This approach keeps the logic reactive and allows the UI to simply
+collect the latest state.
+
+## Building
+
+Run `./gradlew build` to assemble the plugin. The build script uses the
+IntelliJ Platform Gradle Plugin and downloads the required IDE
+distribution automatically.
+
+During development you can launch the IDE with the plugin by executing
+`./gradlew runIde`.


### PR DESCRIPTION
## Summary
- document architecture and flow usage in README
- expand AGENTS with current module structure
- update docs for persistent chat history

## Testing
- `./gradlew build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_688c442ac8ec8320828d964510041276