### PR TITLE
Enable streaming responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Chat with Anthropic models directly from a side panel in your IDE. The chat
 history is persisted in IDE storage so it survives restarts. Configure API
-token, endpoint and model in the settings.
+token, endpoint and model in the settings. Responses stream gradually so you
+can watch them being generated in real time.
 
 <!-- Plugin description -->
 Chat with an Anthropic language model right inside your IDE. The chat history is stored persistently so you can resume conversations after restarting the IDE.

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
-import dev.langchain4j.model.anthropic.AnthropicChatModel
+import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
 import io.qent.sona.core.State
 import io.qent.sona.core.StateProvider
 import io.qent.sona.core.Tools
@@ -32,7 +32,7 @@ class PluginStateFlow(private val project: Project) : StateFlow<State> {
         chatRepository,
         rolesRepository,
         modelFactory = { settings ->
-            AnthropicChatModel.builder()
+            AnthropicStreamingChatModel.builder()
                 .apiKey(settings.apiKey)
                 .baseUrl(settings.apiEndpoint)
                 .modelName(settings.model)


### PR DESCRIPTION
## Summary
- switch to `StreamingChatModel` and implement partial streaming in `ChatFlow`
- persist chat messages only after streaming completes
- create Anthropic streaming model in `PluginStateFlow`
- mention streaming responses in README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688c78362a548320adc837cba9b5785b