### PR TITLE
Implement multi-role system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@
 - Use Compose for all UI components.
 - Settings are stored using a repository interface in the logic module with an IntelliJ implementation in the UI module.
 - Chat history is persisted via a repository implementation (`PluginChatRepository`) that stores chats across IDE sessions.
+- System prompts (roles) are stored in `RolesRepository` and can be managed from
+  the Roles screen. Each role has a name and text and the last role cannot be
+  deleted.
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Chat with an Anthropic language model right inside your IDE. The chat history is
 ## Installation
 Use the IDE plugin manager or download the plugin from releases.
 
+## Roles
+The plugin supports multiple system roles. Open the roles screen from the tool
+window actions to switch between roles or create new ones. Each role has its own
+prompt text. Roles can be added, selected and removed (except the last role).
+
 ## Architecture Overview
 
 The project is split into two modules:

--- a/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
@@ -70,7 +70,8 @@ class ChatFlow(
         val userMessage = ChatRepositoryMessage(chatId, UserMessage.from(text), settings.model)
 
         val baseMessages = if (currentState.messages.isEmpty()) {
-            val systemMessage = ChatRepositoryMessage(chatId, SystemMessage.from(rolesRepository.load()), settings.model)
+            val roleText = rolesRepository.load().let { it.roles[it.active].text }
+            val systemMessage = ChatRepositoryMessage(chatId, SystemMessage.from(roleText), settings.model)
             listOf(systemMessage, userMessage)
         } else {
             currentState.messages + userMessage

--- a/core/src/main/kotlin/io/qent/sona/core/RolesRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/RolesRepository.kt
@@ -1,6 +1,16 @@
 package io.qent.sona.core
 
+data class Role(val name: String, val text: String)
+
+data class Roles(
+    val active: Int = 0,
+    val roles: List<Role> = listOf(Role("Default", "You are an IDE assistant plugin."))
+)
+
 interface RolesRepository {
-    suspend fun load(): String
-    suspend fun save(text: String)
+    /** Load all roles with the active index. */
+    suspend fun load(): Roles
+
+    /** Persist the given roles data. */
+    suspend fun save(roles: Roles)
 }

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -29,7 +29,14 @@ sealed class State {
     }
 
     data class RolesState(
+        val roles: List<String>,
+        val currentIndex: Int,
+        val creating: Boolean,
         val text: String,
+        val onSelectRole: (Int) -> Unit,
+        val onStartCreateRole: () -> Unit,
+        val onAddRole: (String, String) -> Unit,
+        val onDeleteRole: () -> Unit,
         val onSave: (String) -> Unit,
         override val onNewChat: () -> Unit,
         override val onOpenHistory: () -> Unit,

--- a/src/main/kotlin/io/qent/sona/repositories/PluginRolesRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginRolesRepository.kt
@@ -4,12 +4,22 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import io.qent.sona.core.Role
+import io.qent.sona.core.Roles
 import io.qent.sona.core.RolesRepository
 
 @Service
 @State(name = "PluginRoles", storages = [Storage("roles.xml")])
 class PluginRolesRepository : RolesRepository, PersistentStateComponent<PluginRolesRepository.RolesState> {
-    data class RolesState(var text: String = "You are an IDE assistant plugin.")
+    data class StoredRole(
+        var name: String = "Default",
+        var text: String = "You are an IDE assistant plugin."
+    )
+
+    data class RolesState(
+        var active: Int = 0,
+        var roles: MutableList<StoredRole> = mutableListOf(StoredRole())
+    )
 
     private var state = RolesState()
 
@@ -19,9 +29,15 @@ class PluginRolesRepository : RolesRepository, PersistentStateComponent<PluginRo
         this.state = state
     }
 
-    override suspend fun load(): String = state.text
+    override suspend fun load(): Roles = Roles(
+        active = state.active,
+        roles = state.roles.map { Role(it.name, it.text) }
+    )
 
-    override suspend fun save(text: String) {
-        state = state.copy(text = text)
+    override suspend fun save(roles: Roles) {
+        state = RolesState(
+            active = roles.active,
+            roles = roles.roles.map { StoredRole(it.name, it.text) }.toMutableList()
+        )
     }
 }

--- a/src/main/kotlin/io/qent/sona/ui/RolesPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/RolesPanel.kt
@@ -1,31 +1,64 @@
 package io.qent.sona.ui
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.qent.sona.core.State.RolesState
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextArea
+import org.jetbrains.jewel.ui.component.TextField
 
 @Composable
 fun RolesPanel(state: RolesState) {
     val textState = rememberTextFieldState(state.text)
+    var menuExpanded by remember { mutableStateOf(false) }
+    val nameState = rememberTextFieldState()
     Column(Modifier.fillMaxSize().padding(8.dp)) {
+        Row(Modifier.fillMaxWidth()) {
+            if (state.creating) {
+                TextField(nameState, Modifier.weight(1f))
+                Spacer(Modifier.width(8.dp))
+                ActionButton(onClick = {
+                    state.onAddRole(nameState.text.toString(), textState.text.toString())
+                    nameState.clearText()
+                }) { Text("Save") }
+            } else {
+                Column(Modifier.weight(1f)) {
+                    ActionButton(onClick = { menuExpanded = !menuExpanded }, modifier = Modifier.fillMaxWidth()) {
+                        Text(state.roles[state.currentIndex])
+                    }
+                    if (menuExpanded) {
+                        state.roles.forEachIndexed { idx, name ->
+                            ActionButton(
+                                onClick = {
+                                    menuExpanded = false
+                                    state.onSelectRole(idx)
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            ) { Text(name) }
+                        }
+                    }
+                }
+                Spacer(Modifier.width(8.dp))
+                ActionButton(onClick = { nameState.clearText(); textState.clearText(); state.onStartCreateRole() }) { Text("+") }
+                Spacer(Modifier.width(8.dp))
+                ActionButton(onClick = { state.onDeleteRole() }, enabled = state.roles.size > 1) { Text("\uD83D\uDDD1") }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
         TextArea(
             textState,
             Modifier.weight(1f).fillMaxWidth()
         )
         Spacer(Modifier.height(8.dp))
-        ActionButton(onClick = { state.onSave(textState.text.toString()) }, modifier = Modifier.fillMaxWidth()) {
-            Text("Save")
+        if (!state.creating) {
+            ActionButton(onClick = { state.onSave(textState.text.toString()) }, modifier = Modifier.fillMaxWidth()) {
+                Text("Save")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- support multiple named roles via new `RolesRepository` API
- persist roles and active selection in `PluginRolesRepository`
- extend `StateProvider` and `State` for role management actions
- load the selected role when starting a chat
- redesign roles UI with role picker, add and delete buttons
- document roles feature

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688cd48d24c4832085effa6c01c4fc5e