### PR TITLE
Unify plugin theming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,11 @@
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
 
+## Styling
+
+Use `SonaTheme` from `ui/Theme.kt` for all colors and markdown typography. Colors are available via `SonaTheme.colors` and markdown styling via `SonaTheme.markdownColors` and `SonaTheme.markdownTypography`. New composables should rely on these values instead of hard coded colors to keep the look consistent.
+`ThemeService` listens to IDE Look&Feel changes and exposes a `StateFlow<Boolean>` to indicate if the IDE is in dark mode. Wrap top level `JewelComposePanel` contents in `SonaTheme(dark)` using this value so the plugin adapts when the IDE theme changes.
+
 ## Current structure
 
 - **core module** – contains `ChatFlow` and `StateProvider`. `ChatFlow` is a

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Chat history is persisted via `PluginChatRepository`, which uses IntelliJ's
 The UI is written entirely with Compose (via Jewel Compose) in accordance
 with the development guidelines.
 
+### Styling
+
+UI components should be wrapped in `SonaTheme`, which supplies color palettes
+and markdown typography. `ThemeService` tracks IDE theme changes so the plugin
+automatically switches between light and dark palettes.
+
 ### Flow usage
 
 All state propagation relies on Kotlin `Flow`/`StateFlow`:

--- a/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
+++ b/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
@@ -2,6 +2,7 @@ package io.qent.sona
 
 import ChatListPanel
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAware
@@ -14,20 +15,26 @@ import io.qent.sona.core.State.ChatState
 import io.qent.sona.core.State.RolesState
 import io.qent.sona.ui.ChatPanel
 import io.qent.sona.ui.RolesPanel
+import io.qent.sona.ui.SonaTheme
+import io.qent.sona.services.ThemeService
 import org.jetbrains.jewel.bridge.JewelComposePanel
 
 class PluginToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val content = ContentFactory.getInstance().createContent(
             JewelComposePanel {
+                val themeService = service<ThemeService>()
+                val dark by themeService.isDark.collectAsState()
                 val pluginStateFlow = project.service<PluginStateFlow>()
                 val state = pluginStateFlow.collectAsState(pluginStateFlow.lastState)
-                when (val s = state.value) {
-                    is ChatState -> ChatPanel(s)
-                    is ChatListState -> ChatListPanel(s)
-                    is RolesState -> RolesPanel(s)
+                SonaTheme(dark = dark) {
+                    when (val s = state.value) {
+                        is ChatState -> ChatPanel(s)
+                        is ChatListState -> ChatListPanel(s)
+                        is RolesState -> RolesPanel(s)
+                    }
                 }
-          },
+            },
             null,
             false
         )

--- a/src/main/kotlin/io/qent/sona/services/ThemeService.kt
+++ b/src/main/kotlin/io/qent/sona/services/ThemeService.kt
@@ -1,0 +1,19 @@
+package io.qent.sona.services
+
+import javax.swing.UIManager
+import com.intellij.util.ui.UIUtil
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class ThemeService {
+    private val _isDark = MutableStateFlow(UIUtil.isUnderDarcula())
+    val isDark: StateFlow<Boolean> get() = _isDark
+
+    init {
+        UIManager.addPropertyChangeListener {
+            if (it.propertyName == "lookAndFeel") {
+                _isDark.value = UIUtil.isUnderDarcula()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
@@ -3,6 +3,8 @@ package io.qent.sona.settings
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.intellij.openapi.options.Configurable
@@ -10,6 +12,8 @@ import com.intellij.openapi.components.service
 import io.qent.sona.repositories.PluginSettingsRepository
 import javax.swing.JComponent
 import org.jetbrains.jewel.bridge.JewelComposePanel
+import io.qent.sona.ui.SonaTheme
+import io.qent.sona.services.ThemeService
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextField
 
@@ -23,6 +27,8 @@ class PluginSettingsConfigurable : Configurable {
 
     override fun createComponent(): JComponent {
         return JewelComposePanel {
+            val themeService = service<ThemeService>()
+            val dark by themeService.isDark.collectAsState()
             val apiKey = rememberTextFieldState(currentApiKey)
             val apiEndpoint = rememberTextFieldState(currentApiEndpoint)
             val model = rememberTextFieldState(currentModel)
@@ -31,7 +37,8 @@ class PluginSettingsConfigurable : Configurable {
             LaunchedEffect(apiEndpoint.text) { currentApiEndpoint = apiEndpoint.text.toString() }
             LaunchedEffect(model.text) { currentModel = model.text.toString() }
 
-            Column(Modifier.width(600.dp).padding(16.dp)) {
+            SonaTheme(dark = dark) {
+            Column(modifier = Modifier.width(600.dp).padding(16.dp)) {
                 Text("API Key")
                 TextField(
                     apiKey,
@@ -44,6 +51,7 @@ class PluginSettingsConfigurable : Configurable {
                 Text("Model")
                 TextField(model, Modifier.fillMaxWidth())
                 Spacer(Modifier.height(16.dp))
+            }
             }
         }
     }

--- a/src/main/kotlin/io/qent/sona/ui/ChatListPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatListPanel.kt
@@ -1,3 +1,4 @@
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,9 +9,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.qent.sona.core.State.ChatListState
+import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
 import java.text.SimpleDateFormat
@@ -19,7 +23,12 @@ import java.util.Date
 @Composable
 fun ChatListPanel(state: ChatListState) {
     val listState = rememberLazyListState()
-    Column(Modifier.fillMaxSize().padding(8.dp)) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(SonaTheme.colors.Background)
+            .padding(8.dp)
+    ) {
         LazyColumn(
             state = listState,
             modifier = Modifier
@@ -31,16 +40,18 @@ fun ChatListPanel(state: ChatListState) {
                 Row(
                     Modifier
                         .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(SonaTheme.colors.AiBubble)
                         .clickable(onClick = { state.onOpenChat(chat.id) })
-                        .padding(vertical = 6.dp, horizontal = 4.dp),
+                        .padding(vertical = 6.dp, horizontal = 8.dp),
                     verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
                 ) {
                     Column(
                         Modifier.weight(1f)
                     ) {
-                        Text(chat.firstMessage, maxLines = 1)
+                        Text(chat.firstMessage, maxLines = 1, color = SonaTheme.colors.AiText)
                         val date = SimpleDateFormat("yyyy-MM-dd HH:mm").format(Date(chat.createdAt))
-                        Text(date, fontSize = 12.sp)
+                        Text(date, fontSize = 12.sp, color = SonaTheme.colors.Placeholder)
                     }
                     ActionButton(
                         onClick = {

--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -33,25 +33,14 @@ import io.qent.sona.core.State.ChatState
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
 
-object ChatColors {
-    val Background = Color(0xFF20232A)
-    val UserBubble = Color(0xFF3366FF)
-    val AiBubble = Color(0xFF292D36)
-    val UserText = Color.White
-    val AiText = Color(0xFFD3D8DF)
-    val InputBackground = Color(0xFF22262A)
-    val Placeholder = Color(0xFF7A818A)
-    val BubbleShadow = Color(0x22000000)
-    val BorderFocused = Color(0xFF3B72FF)
-    val BorderDefault = Color(0xFF373B42)
-}
+import io.qent.sona.ui.SonaTheme
 
 @Composable
 fun ChatPanel(state: ChatState) {
     Column(
         Modifier
             .fillMaxSize()
-            .background(ChatColors.Background)
+            .background(SonaTheme.colors.Background)
     ) {
         Header(state)
         Box(
@@ -109,8 +98,8 @@ private fun Messages(state: ChatState, modifier: Modifier = Modifier) {
 @Composable
 fun MessageBubble(message: Any, isUser: Boolean) {
     var hovered by remember { mutableStateOf(false) }
-    val background = if (isUser) ChatColors.UserBubble else ChatColors.AiBubble
-    val textColor = if (isUser) ChatColors.UserText else ChatColors.AiText
+    val background = if (isUser) SonaTheme.colors.UserBubble else SonaTheme.colors.AiBubble
+    val textColor = if (isUser) SonaTheme.colors.UserText else SonaTheme.colors.AiText
     Box(
         Modifier
             .pointerInput(Unit) {
@@ -127,8 +116,8 @@ fun MessageBubble(message: Any, isUser: Boolean) {
             val mdState = rememberMarkdownState(message.text(), immediate = true)
             Markdown(
                 mdState,
-                colors = Colors.Dark,
-                typography = Typography.Dark,
+                colors = SonaTheme.markdownColors,
+                typography = SonaTheme.markdownTypography,
             )
         } else if (message is UserMessage) {
             Text(
@@ -143,12 +132,12 @@ fun MessageBubble(message: Any, isUser: Boolean) {
 @Composable
 fun AiAvatar() {
     Box(
-        Modifier
+        modifier = Modifier
             .size(28.dp)
-            .background(Color(0xFF8E98A9), shape = CircleShape),
+            .background(SonaTheme.colors.AvatarBackground, shape = CircleShape),
         contentAlignment = Alignment.Center
     ) {
-        Text("🤖", fontSize = 16.sp)
+        Text("\uD83E\uDD16", fontSize = 16.sp)
     }
 }
 
@@ -159,17 +148,17 @@ private fun Input(state: ChatState) {
     Box(
         Modifier
             .fillMaxWidth()
-            .background(ChatColors.InputBackground)
+            .background(SonaTheme.colors.InputBackground)
             .padding(12.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Box(
                 Modifier
                     .weight(1f)
-                    .background(ChatColors.Background, RoundedCornerShape(12.dp))
+                    .background(SonaTheme.colors.Background, RoundedCornerShape(12.dp))
                     .border(
                         1.dp,
-                        if (isFocused) ChatColors.BorderFocused else ChatColors.BorderDefault,
+                        if (isFocused) SonaTheme.colors.BorderFocused else SonaTheme.colors.BorderDefault,
                         RoundedCornerShape(12.dp)
                     )
                     .padding(horizontal = 12.dp, vertical = 8.dp)
@@ -177,7 +166,7 @@ private fun Input(state: ChatState) {
                 if (text.value.isEmpty()) {
                     Text(
                         "Напишите сообщение...",
-                        color = ChatColors.Placeholder,
+                        color = SonaTheme.colors.Placeholder,
                         fontSize = 14.sp
                     )
                 }
@@ -200,7 +189,7 @@ private fun Input(state: ChatState) {
                             }
                         },
                     textStyle = TextStyle(
-                        color = Color.White,
+                        color = SonaTheme.colors.UserText,
                         fontSize = 14.sp
                     ),
                     singleLine = true,

--- a/src/main/kotlin/io/qent/sona/ui/RolesPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/RolesPanel.kt
@@ -1,12 +1,16 @@
 package io.qent.sona.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.input.clearText
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import io.qent.sona.core.State.RolesState
+import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextArea
@@ -17,7 +21,12 @@ fun RolesPanel(state: RolesState) {
     val textState = rememberTextFieldState(state.text)
     var menuExpanded by remember { mutableStateOf(false) }
     val nameState = rememberTextFieldState()
-    Column(Modifier.fillMaxSize().padding(8.dp)) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(SonaTheme.colors.Background)
+            .padding(8.dp)
+    ) {
         Row(Modifier.fillMaxWidth()) {
             if (state.creating) {
                 TextField(nameState, Modifier.weight(1f))
@@ -52,7 +61,11 @@ fun RolesPanel(state: RolesState) {
         Spacer(Modifier.height(8.dp))
         TextArea(
             textState,
-            Modifier.weight(1f).fillMaxWidth()
+            Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(SonaTheme.colors.InputBackground)
         )
         Spacer(Modifier.height(8.dp))
         if (!state.creating) {

--- a/src/main/kotlin/io/qent/sona/ui/Theme.kt
+++ b/src/main/kotlin/io/qent/sona/ui/Theme.kt
@@ -1,0 +1,74 @@
+package io.qent.sona.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+data class SonaColors(
+    val Background: Color,
+    val UserBubble: Color,
+    val AiBubble: Color,
+    val UserText: Color,
+    val AiText: Color,
+    val InputBackground: Color,
+    val Placeholder: Color,
+    val BubbleShadow: Color,
+    val BorderFocused: Color,
+    val BorderDefault: Color,
+    val AvatarBackground: Color,
+)
+
+private val DarkPalette = SonaColors(
+    Background = Color(0xFF20232A),
+    UserBubble = Color(0xFF3366FF),
+    AiBubble = Color(0xFF292D36),
+    UserText = Color.White,
+    AiText = Color(0xFFD3D8DF),
+    InputBackground = Color(0xFF22262A),
+    Placeholder = Color(0xFF7A818A),
+    BubbleShadow = Color(0x22000000),
+    BorderFocused = Color(0xFF3B72FF),
+    BorderDefault = Color(0xFF373B42),
+    AvatarBackground = Color(0xFF8E98A9),
+)
+
+private val LightPalette = SonaColors(
+    Background = Color(0xFFFFFFFF),
+    UserBubble = Color(0xFF3366FF),
+    AiBubble = Color(0xFFF0F0F0),
+    UserText = Color.Black,
+    AiText = Color(0xFF333333),
+    InputBackground = Color(0xFFE8E8E8),
+    Placeholder = Color(0xFF6E6E6E),
+    BubbleShadow = Color(0x22000000),
+    BorderFocused = Color(0xFF3B72FF),
+    BorderDefault = Color(0xFFC4C4C4),
+    AvatarBackground = Color(0xFFC8C8C8),
+)
+
+private val LocalColors = staticCompositionLocalOf { DarkPalette }
+private val LocalMarkdownColors = staticCompositionLocalOf { MarkdownColors.Dark }
+private val LocalTypography = staticCompositionLocalOf { Typography.Dark }
+
+@Composable
+fun SonaTheme(dark: Boolean, content: @Composable () -> Unit) {
+    val colors = if (dark) DarkPalette else LightPalette
+    val mdColors = if (dark) MarkdownColors.Dark else MarkdownColors.Light
+    val mdTypography = if (dark) Typography.Dark else Typography.Light
+    CompositionLocalProvider(
+        LocalColors provides colors,
+        LocalMarkdownColors provides mdColors,
+        LocalTypography provides mdTypography,
+        content = content
+    )
+}
+
+object SonaTheme {
+    val colors: SonaColors
+        @Composable get() = LocalColors.current
+    val markdownColors
+        @Composable get() = LocalMarkdownColors.current
+    val markdownTypography
+        @Composable get() = LocalTypography.current
+}

--- a/src/main/kotlin/io/qent/sona/ui/Typography.kt
+++ b/src/main/kotlin/io/qent/sona/ui/Typography.kt
@@ -11,126 +11,177 @@ import androidx.compose.ui.unit.sp
 import com.mikepenz.markdown.model.DefaultMarkdownColors
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 
-val MarkdownTextColor = Color(0xFFA9B7C6)
-val MarkdownCodeForegroundColor = Color(0xFFBBB529)
-val MarkdownInlineCodeForegroundColor = Color(0xFFFFC66D)
-val MarkdownLinkColor = Color(0xFF589DF6)
-val MarkdownCodeBackgroundColor = Color(0xFF2B2B2B)
-val MarkdownInlineCodeBackgroundColor = Color(0xFF3C3F41)
-val MarkdownQuoteColor = Color(0xFF629755)
-val MarkdownDividerColor = Color(0xFF3C3F41)
-val MarkdownTableBackgroundColor = Color(0xFF2B2B2B)
-val MarkdownTableTextColor = Color(0xFFA9B7C6)
-val MarkdownLinkHoveredColor = Color(0xFF40C4FF)
-val MarkdownLinkFocusedColor = Color(0xFF9876AA)
-val MarkdownLinkPressedColor = Color(0xFF40C4FF)
+val MarkdownDarkTextColor = Color(0xFFA9B7C6)
+val MarkdownDarkCodeForegroundColor = Color(0xFFBBB529)
+val MarkdownDarkInlineCodeForegroundColor = Color(0xFFFFC66D)
+val MarkdownDarkLinkColor = Color(0xFF589DF6)
+val MarkdownDarkCodeBackgroundColor = Color(0xFF2B2B2B)
+val MarkdownDarkInlineCodeBackgroundColor = Color(0xFF3C3F41)
+val MarkdownDarkQuoteColor = Color(0xFF629755)
+val MarkdownDarkDividerColor = Color(0xFF3C3F41)
+val MarkdownDarkTableBackgroundColor = Color(0xFF2B2B2B)
+val MarkdownDarkTableTextColor = Color(0xFFA9B7C6)
+val MarkdownDarkLinkHoveredColor = Color(0xFF40C4FF)
+val MarkdownDarkLinkFocusedColor = Color(0xFF9876AA)
+val MarkdownDarkLinkPressedColor = Color(0xFF40C4FF)
+
+val MarkdownLightTextColor = Color(0xFF000000)
+val MarkdownLightCodeForegroundColor = Color(0xFF6A8759)
+val MarkdownLightInlineCodeForegroundColor = Color(0xFF6A8759)
+val MarkdownLightLinkColor = Color(0xFF0066CC)
+val MarkdownLightCodeBackgroundColor = Color(0xFFE6E6E6)
+val MarkdownLightInlineCodeBackgroundColor = Color(0xFFDADADA)
+val MarkdownLightQuoteColor = Color(0xFF6A8759)
+val MarkdownLightDividerColor = Color(0xFFDADADA)
+val MarkdownLightTableBackgroundColor = Color(0xFFE6E6E6)
+val MarkdownLightTableTextColor = Color(0xFF000000)
+val MarkdownLightLinkHoveredColor = Color(0xFF005BB5)
+val MarkdownLightLinkFocusedColor = Color(0xFF663399)
+val MarkdownLightLinkPressedColor = Color(0xFF005BB5)
 
 object Typography {
     val Dark = DefaultMarkdownTypography(
         h1 = TextStyle(
             fontSize = 28.sp,
             fontWeight = FontWeight.Bold,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         h2 = TextStyle(
             fontSize = 24.sp,
             fontWeight = FontWeight.Bold,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         h3 = TextStyle(
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         h4 = TextStyle(
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         h5 = TextStyle(
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         h6 = TextStyle(
             fontSize = 14.sp,
             fontWeight = FontWeight.SemiBold,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         text = TextStyle(
             fontSize = 14.sp,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         code = TextStyle(
             fontSize = 14.sp,
             fontFamily = FontFamily.Monospace,
-            color = MarkdownCodeForegroundColor,
-            background = MarkdownCodeBackgroundColor
+            color = MarkdownDarkCodeForegroundColor,
+            background = MarkdownDarkCodeBackgroundColor
         ),
         inlineCode = TextStyle(
             fontSize = 14.sp,
             fontFamily = FontFamily.Monospace,
-            color = MarkdownInlineCodeForegroundColor,
-            background = MarkdownInlineCodeBackgroundColor
+            color = MarkdownDarkInlineCodeForegroundColor,
+            background = MarkdownDarkInlineCodeBackgroundColor
         ),
         quote = TextStyle(
             fontSize = 14.sp,
-            color = MarkdownQuoteColor,
+            color = MarkdownDarkQuoteColor,
             fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
         ),
         paragraph = TextStyle(
             fontSize = 14.sp,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         ordered = TextStyle(
             fontSize = 14.sp,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         bullet = TextStyle(
             fontSize = 14.sp,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         list = TextStyle(
             fontSize = 14.sp,
-            color = MarkdownTextColor
+            color = MarkdownDarkTextColor
         ),
         link = TextStyle(
             fontSize = 14.sp,
-            color = MarkdownLinkColor,
+            color = MarkdownDarkLinkColor,
             textDecoration = TextDecoration.Underline
         ),
         textLink = TextLinkStyles(
             style = SpanStyle(
-                color = MarkdownLinkColor,
+                color = MarkdownDarkLinkColor,
                 textDecoration = TextDecoration.Underline
             ),
             hoveredStyle = SpanStyle(
-                color = MarkdownLinkHoveredColor
+                color = MarkdownDarkLinkHoveredColor
             ),
             focusedStyle = SpanStyle(
-                color = MarkdownLinkFocusedColor
+                color = MarkdownDarkLinkFocusedColor
             ),
             pressedStyle = SpanStyle(
-                color = MarkdownLinkPressedColor
+                color = MarkdownDarkLinkPressedColor
             )
         ),
         table = TextStyle(
             fontSize = 14.sp,
-            color = MarkdownTableTextColor
+            color = MarkdownDarkTableTextColor
         ),
+    )
+
+    val Light = DefaultMarkdownTypography(
+        h1 = TextStyle(fontSize = 28.sp, fontWeight = FontWeight.Bold, color = MarkdownLightTextColor),
+        h2 = TextStyle(fontSize = 24.sp, fontWeight = FontWeight.Bold, color = MarkdownLightTextColor),
+        h3 = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold, color = MarkdownLightTextColor),
+        h4 = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Bold, color = MarkdownLightTextColor),
+        h5 = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold, color = MarkdownLightTextColor),
+        h6 = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = MarkdownLightTextColor),
+        text = TextStyle(fontSize = 14.sp, color = MarkdownLightTextColor),
+        code = TextStyle(fontSize = 14.sp, fontFamily = FontFamily.Monospace, color = MarkdownLightCodeForegroundColor, background = MarkdownLightCodeBackgroundColor),
+        inlineCode = TextStyle(fontSize = 14.sp, fontFamily = FontFamily.Monospace, color = MarkdownLightInlineCodeForegroundColor, background = MarkdownLightInlineCodeBackgroundColor),
+        quote = TextStyle(fontSize = 14.sp, color = MarkdownLightQuoteColor, fontStyle = androidx.compose.ui.text.font.FontStyle.Italic),
+        paragraph = TextStyle(fontSize = 14.sp, color = MarkdownLightTextColor),
+        ordered = TextStyle(fontSize = 14.sp, color = MarkdownLightTextColor),
+        bullet = TextStyle(fontSize = 14.sp, color = MarkdownLightTextColor),
+        list = TextStyle(fontSize = 14.sp, color = MarkdownLightTextColor),
+        link = TextStyle(fontSize = 14.sp, color = MarkdownLightLinkColor, textDecoration = TextDecoration.Underline),
+        textLink = TextLinkStyles(
+            style = SpanStyle(color = MarkdownLightLinkColor, textDecoration = TextDecoration.Underline),
+            hoveredStyle = SpanStyle(color = MarkdownLightLinkHoveredColor),
+            focusedStyle = SpanStyle(color = MarkdownLightLinkFocusedColor),
+            pressedStyle = SpanStyle(color = MarkdownLightLinkPressedColor)
+        ),
+        table = TextStyle(fontSize = 14.sp, color = MarkdownLightTableTextColor),
     )
 }
 
-object Colors {
+object MarkdownColors {
     val Dark = DefaultMarkdownColors(
-        text = MarkdownTextColor,
-        codeText = MarkdownCodeForegroundColor,
-        inlineCodeText = MarkdownInlineCodeForegroundColor,
-        linkText = MarkdownLinkColor,
-        codeBackground = MarkdownCodeBackgroundColor,
-        inlineCodeBackground = MarkdownInlineCodeBackgroundColor,
-        dividerColor = MarkdownDividerColor,
-        tableText = MarkdownTableTextColor,
-        tableBackground = MarkdownTableBackgroundColor,
+        text = MarkdownDarkTextColor,
+        codeText = MarkdownDarkCodeForegroundColor,
+        inlineCodeText = MarkdownDarkInlineCodeForegroundColor,
+        linkText = MarkdownDarkLinkColor,
+        codeBackground = MarkdownDarkCodeBackgroundColor,
+        inlineCodeBackground = MarkdownDarkInlineCodeBackgroundColor,
+        dividerColor = MarkdownDarkDividerColor,
+        tableText = MarkdownDarkTableTextColor,
+        tableBackground = MarkdownDarkTableBackgroundColor,
+    )
+
+    val Light = DefaultMarkdownColors(
+        text = MarkdownLightTextColor,
+        codeText = MarkdownLightCodeForegroundColor,
+        inlineCodeText = MarkdownLightInlineCodeForegroundColor,
+        linkText = MarkdownLightLinkColor,
+        codeBackground = MarkdownLightCodeBackgroundColor,
+        inlineCodeBackground = MarkdownLightInlineCodeBackgroundColor,
+        dividerColor = MarkdownLightDividerColor,
+        tableText = MarkdownLightTableTextColor,
+        tableBackground = MarkdownLightTableBackgroundColor,
     )
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,7 @@
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginSettingsRepository"/>
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginChatRepository"/>
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginRolesRepository"/>
+        <applicationService serviceImplementation="io.qent.sona.services.ThemeService"/>
 
         <applicationConfigurable
                 id="SonaChatSettings"


### PR DESCRIPTION
## Summary
- redesign SonaTheme as a `compositionLocalOf` theme with light & dark palettes
- provide ThemeService to track IDE theme changes and expose them to Compose
- wrap tool window & settings UI in `SonaTheme` so colors update automatically
- update ChatPanel avatar color and general code style
- document styling workflow in AGENTS and README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688cff0de3208320a032073cd1879bb1