### PR TITLE
feat: allow cancelling streaming responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Chat with Anthropic models directly from a side panel in your IDE. The chat
 history is persisted in IDE storage so it survives restarts. Configure API
 token, endpoint and model in the settings. Responses stream gradually so you
-can watch them being generated in real time.
+can watch them being generated in real time and stop the stream at any moment
+to keep the partial reply.
 
 <!-- Plugin description -->
 Chat with an Anthropic language model right inside your IDE. The chat history is stored persistently so you can resume conversations after restarting the IDE.

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -13,6 +13,7 @@ sealed class State {
         val inputTokens: Int,
         val isSending: Boolean,
         val onSendMessage: (String) -> Unit,
+        val onStop: () -> Unit,
         override val onNewChat: () -> Unit,
         override val onOpenHistory: () -> Unit,
         override val onOpenRoles: () -> Unit,

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -45,6 +45,7 @@ class StateProvider(
                 tokenUsage.inputTokenCount(),
                 isSending = requestInProgress,
                 onSendMessage = { text -> scope.launch { send(text) } },
+                onStop = { scope.launch { stop() } },
                 onNewChat = { scope.launch { newChat() } },
                 onOpenHistory = { scope.launch { showHistory() } },
                 onOpenRoles = { scope.launch { showRoles() } },
@@ -156,4 +157,5 @@ class StateProvider(
     }
 
     private suspend fun send(text: String) = chatFlow.send(text)
+    private fun stop() = chatFlow.stop()
 }

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -47,7 +47,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
         }, scope = scope
     )
 
-    var lastState: State = State.ChatState(emptyList(), 0, 0, false, {}, {}, {}, {})
+    var lastState: State = State.ChatState(emptyList(), 0, 0, false, {}, {}, {}, {}, {})
 
     init {
         stateProvider.state.onEach {

--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -198,17 +198,26 @@ private fun Input(state: ChatState) {
                 )
             }
             Spacer(Modifier.width(8.dp))
-            ActionButton(
-                onClick = {
-                    if (text.value.isNotBlank()) {
-                        state.onSendMessage(text.value)
-                        text.value = ""
-                    }
-                },
-                enabled = text.value.isNotBlank() && !state.isSending,
-                modifier = Modifier.height(40.dp)
-            ) {
-                Text("➤")
+            if (state.isSending) {
+                ActionButton(
+                    onClick = { state.onStop() },
+                    modifier = Modifier.height(40.dp)
+                ) {
+                    Text("■")
+                }
+            } else {
+                ActionButton(
+                    onClick = {
+                        if (text.value.isNotBlank()) {
+                            state.onSendMessage(text.value)
+                            text.value = ""
+                        }
+                    },
+                    enabled = text.value.isNotBlank(),
+                    modifier = Modifier.height(40.dp)
+                ) {
+                    Text("➤")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow ChatFlow to cancel in-progress model requests
- expose stop callback through state and UI
- update README to mention stopping a streaming reply

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688db29eabb88320bd76ba1159836e65