### PR TITLE
refactor: extract reusable dropdown selector

### DIFF
--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -1,4 +1,3 @@
-
 package io.qent.sona.ui
 
 import androidx.compose.foundation.background
@@ -16,10 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
@@ -29,11 +24,8 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.zIndex
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.model.rememberMarkdownState
 import dev.langchain4j.data.message.AiMessage
@@ -154,17 +146,13 @@ fun AiAvatar() {
 private fun Input(state: ChatState) {
     val text = remember { mutableStateOf("") }
     var isFocused by remember { mutableStateOf(false) }
-    var menuExpanded by remember { mutableStateOf(false) }
-    var buttonPosition by remember { mutableStateOf(Offset.Zero) }
-    var buttonSize by remember { mutableStateOf(IntSize.Zero) }
-    var containerPosition by remember { mutableStateOf(Offset.Zero) }
+
 
     Box(
         Modifier
             .fillMaxWidth()
             .background(SonaTheme.colors.InputBackground)
             .padding(12.dp)
-            .onGloballyPositioned { containerPosition = it.positionInRoot() }
     ) {
         Row(
             modifier = Modifier.align(Alignment.TopStart),
@@ -238,42 +226,12 @@ private fun Input(state: ChatState) {
             }
         }
 
-        ActionButton(
-            onClick = { menuExpanded = !menuExpanded },
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .onGloballyPositioned {
-                    buttonPosition = it.positionInRoot()
-                    buttonSize = it.size
-                }
-        ) {
-            Text(state.roles[state.activeRole])
-        }
-
-        if (menuExpanded) {
-            Column(
-                modifier = Modifier
-                    .offset {
-                        IntOffset(
-                            x = (buttonPosition.x - containerPosition.x).toInt(),
-                            y = (buttonPosition.y - containerPosition.y - buttonSize.height * state.roles.size).toInt()
-                        )
-                    }
-                    .width(with(LocalDensity.current) { buttonSize.width.toDp() })
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(SonaTheme.colors.InputBackground)
-                    .zIndex(1f)
-            ) {
-                state.roles.forEachIndexed { idx, name ->
-                    ActionButton(
-                        onClick = {
-                            menuExpanded = false
-                            state.onSelectRole(idx)
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    ) { Text(name) }
-                }
-            }
-        }
+        DropdownSelector(
+            items = state.roles,
+            selectedIndex = state.activeRole,
+            expandUpwards = true,
+            onSelect = { state.onSelectRole(it) },
+            modifier = Modifier.align(Alignment.BottomStart)
+        )
     }
 }

--- a/src/main/kotlin/io/qent/sona/ui/DropdownSelector.kt
+++ b/src/main/kotlin/io/qent/sona/ui/DropdownSelector.kt
@@ -1,0 +1,120 @@
+package io.qent.sona.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import org.jetbrains.jewel.ui.component.ActionButton
+import org.jetbrains.jewel.ui.component.Text
+
+/**
+ * Reusable dropdown selector that can expand either upward or downward.
+ *
+ * @param items list of display names.
+ * @param selectedIndex index of currently selected item.
+ * @param expandUpwards if true the list expands upward, otherwise downward.
+ * @param onSelect callback invoked with the index of the chosen item.
+ * @param modifier modifier applied to the container box.
+ * @param buttonModifier modifier applied to the toggle button.
+ */
+@Composable
+fun DropdownSelector(
+    items: List<String>,
+    selectedIndex: Int,
+    expandUpwards: Boolean,
+    onSelect: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    buttonModifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var buttonPosition by remember { mutableStateOf(Offset.Zero) }
+    var buttonSize by remember { mutableStateOf(IntSize.Zero) }
+    var containerPosition by remember { mutableStateOf(Offset.Zero) }
+
+    val currentItems by rememberUpdatedState(items)
+    val filtered = remember(currentItems, selectedIndex) {
+        currentItems.mapIndexedNotNull { index, name ->
+            if (index != selectedIndex) index to name else null
+        }
+    }
+
+    Box(
+        modifier = modifier.onGloballyPositioned { containerPosition = it.positionInRoot() }
+    ) {
+        ActionButton(
+            onClick = { expanded = !expanded },
+            modifier = buttonModifier.onGloballyPositioned {
+                buttonPosition = it.positionInRoot()
+                buttonSize = it.size
+            }
+        ) {
+            Text(items[selectedIndex])
+        }
+
+        if (expanded && filtered.isNotEmpty()) {
+            Column(
+                modifier = Modifier
+                    .offset {
+                        val x = (buttonPosition.x - containerPosition.x).toInt()
+                        val y = if (expandUpwards) {
+                            (buttonPosition.y - containerPosition.y - buttonSize.height * filtered.size).toInt()
+                        } else {
+                            (buttonPosition.y - containerPosition.y + buttonSize.height).toInt()
+                        }
+                        IntOffset(x, y)
+                    }
+                    .width(with(LocalDensity.current) { buttonSize.width.toDp() })
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(SonaTheme.colors.InputBackground)
+                    .zIndex(1f)
+            ) {
+                if (!expandUpwards) {
+                    Text(
+                        items[selectedIndex],
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 8.dp)
+                    )
+                }
+                filtered.forEach { (idx, name) ->
+                    ActionButton(
+                        onClick = {
+                            expanded = false
+                            onSelect(idx)
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) { Text(name) }
+                }
+                if (expandUpwards) {
+                    Text(
+                        items[selectedIndex],
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 8.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+

--- a/src/main/kotlin/io/qent/sona/ui/RolesPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/RolesPanel.kt
@@ -9,15 +9,7 @@ import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.width
-import androidx.compose.ui.zIndex
 import io.qent.sona.core.State.RolesState
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
@@ -26,11 +18,7 @@ import org.jetbrains.jewel.ui.component.TextArea
 @Composable
 fun RolesPanel(state: RolesState) {
     val textState = rememberTextFieldState(state.text)
-    var menuExpanded by remember { mutableStateOf(false) }
     val nameState = rememberTextFieldState()
-
-    var buttonPosition by remember { mutableStateOf(Offset.Zero) }
-    var buttonSize by remember { mutableStateOf(IntSize.Zero) }
 
     LaunchedEffect(state.currentIndex) {
         if (textState.text != state.text) {
@@ -49,21 +37,14 @@ fun RolesPanel(state: RolesState) {
                 .padding(8.dp)
         ) {
             Row(Modifier.fillMaxWidth()) {
-
-                // Role selector button wrapped in Box so we can capture its position
-                Box(Modifier.weight(1f)) {
-                    ActionButton(
-                        onClick = { menuExpanded = !menuExpanded },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .onGloballyPositioned { coords ->
-                                buttonPosition = coords.positionInRoot()
-                                buttonSize = coords.size
-                            }
-                    ) {
-                        Text(state.roles[state.currentIndex])
-                    }
-                }
+                DropdownSelector(
+                    items = state.roles,
+                    selectedIndex = state.currentIndex,
+                    expandUpwards = false,
+                    onSelect = { state.onSelectRole(it) },
+                    modifier = Modifier.weight(1f),
+                    buttonModifier = Modifier.fillMaxWidth()
+                )
 
                 Spacer(Modifier.width(8.dp))
                 ActionButton(
@@ -100,33 +81,6 @@ fun RolesPanel(state: RolesState) {
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text("Save")
-                }
-            }
-        }
-
-        // Overlay dropdown menu – sits on top of everything else without affecting layout
-        if (menuExpanded) {
-            Column(
-                modifier = Modifier
-                    .offset {
-                        IntOffset(
-                            x = buttonPosition.x.toInt(),
-                            y = buttonPosition.y.toInt() + buttonSize.height
-                        )
-                    }
-                    .width(with(LocalDensity.current) { buttonSize.width.toDp() })
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(SonaTheme.colors.InputBackground)
-                    .zIndex(1f)
-            ) {
-                state.roles.forEachIndexed { idx, name ->
-                    ActionButton(
-                        onClick = {
-                            menuExpanded = false
-                            state.onSelectRole(idx)
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    ) { Text(name) }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace duplicate dropdown menus with reusable `DropdownSelector`
- support expanding up or down and filter active item

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688e2ea5ee248320bf75dbfe36655bf4