### PR TITLE
Upload release asset in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,3 +251,8 @@ jobs:
           ${{ needs.build.outputs.changelog }}
           EOM
           )"
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "v${{ needs.build.outputs.version }}" ./build/distributions/*.zip


### PR DESCRIPTION
## Summary
- upload build zip to release draft via `gh release upload`

## Testing
- `./gradlew build`
- `./gradlew buildPlugin`
- `gh release upload "v0.0.1" build/distributions/sona-0.0.1.zip` *(fails: no git remotes/401)*

------
https://chatgpt.com/codex/tasks/task_e_688f067a23788320b92b323270c4e753