### PR TITLE
feat: add configurable LLM presets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@
 - System prompts (roles) are stored in `RolesRepository` and can be managed from
   the Roles screen. Each role has a name and text and the last role cannot be
   deleted.
+- LLM connection details are organised as presets via `PresetsRepository`. At least one preset must exist for the chat to work and they are managed from the Presets screen.
+- Plugin settings contain only the "Ignore HTTPS errors" flag which, when enabled, trusts all HTTPS certificates.
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # sona
 
-Chat with Anthropic models directly from a side panel in your IDE. The chat
-history is persisted in IDE storage so it survives restarts. Configure API
-token, endpoint and model in the settings. Responses stream gradually so you
-can watch them being generated in real time and stop the stream at any moment
+Chat with various language models directly from a side panel in your IDE. The chat
+history is persisted in IDE storage so it survives restarts. Connection details are
+managed as presets where you choose a provider, model, API endpoint and token. Responses stream
+gradually so you can watch them being generated in real time and stop the stream at any moment
 to keep the partial reply.
 
 <!-- Plugin description -->
-Chat with an Anthropic language model right inside your IDE. The chat history is stored persistently so you can resume conversations after restarting the IDE.
+Chat with Anthropic, OpenAI, Deepseek or Gemini models right inside your IDE. The chat history is stored persistently so you can resume conversations after restarting the IDE.
 <!-- Plugin description end -->
 
 ## Installation
@@ -23,6 +23,15 @@ prompt text. Roles can be added, selected and removed (except the last role).
 The active role can also be changed directly from the chat via the selector
 under the message input. The text of the active role is sent as a system
 message with every request but is not stored in the chat history.
+
+## Presets
+
+LLM credentials are stored as presets. Each preset defines the provider, model,
+API endpoint and token. Manage presets from the Presets screen opened via the
+tool window actions. At least one preset must exist for the chat to function.
+
+The settings screen contains only a single option: **Ignore HTTPS errors**. Enable
+it to trust all HTTPS certificates when connecting to custom endpoints.
 
 ## Architecture Overview
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,14 @@ dependencies {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
     }
+    implementation(libs.langchain4j.openai) {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+    }
+    implementation(libs.langchain4j.google.ai.gemini) {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+    }
 
     compileOnly("com.intellij.platform:kotlinx-coroutines-core-jvm:1.8.0-intellij-13")
 

--- a/core/src/main/kotlin/io/qent/sona/core/PresetsRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/PresetsRepository.kt
@@ -1,0 +1,39 @@
+package io.qent.sona.core
+
+enum class LlmProvider(val defaultEndpoint: String, val models: List<String>) {
+    Anthropic(
+        "https://api.anthropic.com/v1/",
+        listOf("sonet 3.7", "sonet 4.0", "haiku 3.5"),
+    ),
+    OpenAI(
+        "https://api.openai.com/v1/",
+        listOf("o3", "4.1"),
+    ),
+    Deepseek(
+        "https://api.deepseek.com/v1/",
+        listOf("v3"),
+    ),
+    Gemini(
+        "https://generativelanguage.googleapis.com/v1beta/",
+        listOf("2.5"),
+    );
+}
+
+data class Preset(
+    val name: String,
+    val provider: LlmProvider,
+    val apiEndpoint: String,
+    val model: String,
+    val apiKey: String,
+)
+
+data class Presets(
+    val active: Int,
+    val presets: List<Preset>,
+)
+
+interface PresetsRepository {
+    suspend fun load(): Presets
+    suspend fun save(presets: Presets)
+}
+

--- a/core/src/main/kotlin/io/qent/sona/core/Settings.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/Settings.kt
@@ -1,7 +1,5 @@
 package io.qent.sona.core
 
 data class Settings(
-    val apiKey: String,
-    val apiEndpoint: String,
-    val model: String
+    val ignoreHttpsErrors: Boolean
 )

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -6,6 +6,7 @@ sealed class State {
     abstract val onNewChat: () -> Unit
     abstract val onOpenHistory: () -> Unit
     abstract val onOpenRoles: () -> Unit
+    abstract val onOpenPresets: () -> Unit
 
     data class ChatState(
         val messages: List<ChatMessage>,
@@ -20,6 +21,7 @@ sealed class State {
         override val onNewChat: () -> Unit,
         override val onOpenHistory: () -> Unit,
         override val onOpenRoles: () -> Unit,
+        override val onOpenPresets: () -> Unit,
     ) : State()
 
     data class ChatListState(
@@ -28,6 +30,7 @@ sealed class State {
         val onDeleteChat: (String) -> Unit,
         override val onNewChat: () -> Unit,
         override val onOpenRoles: () -> Unit,
+        override val onOpenPresets: () -> Unit,
     ) : State() {
         override val onOpenHistory = { }
     }
@@ -44,7 +47,24 @@ sealed class State {
         val onSave: (String) -> Unit,
         override val onNewChat: () -> Unit,
         override val onOpenHistory: () -> Unit,
+        override val onOpenRoles: () -> Unit,
+        override val onOpenPresets: () -> Unit,
+    ) : State()
+
+    data class PresetsState(
+        val presets: List<String>,
+        val currentIndex: Int,
+        val creating: Boolean,
+        val preset: Preset,
+        val onSelectPreset: (Int) -> Unit,
+        val onStartCreatePreset: () -> Unit,
+        val onAddPreset: (Preset) -> Unit,
+        val onDeletePreset: () -> Unit,
+        val onSave: (Preset) -> Unit,
+        override val onNewChat: () -> Unit,
+        override val onOpenHistory: () -> Unit,
+        override val onOpenRoles: () -> Unit,
     ) : State() {
-        override val onOpenRoles = { }
+        override val onOpenPresets = { }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ qodana = "2024.3.4"
 langchain4j_core = "1.0.0"
 langchain4j_kotlin = "1.0.0-beta5"
 langchain4j_anthropic = "1.0.0-beta5"
+langchain4j_openai = "1.2.0"
+langchain4j_google_ai_gemini = "1.2.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -17,6 +19,8 @@ opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "ope
 langchain4j-core = { group = "dev.langchain4j", name = "langchain4j-core", version.ref = "langchain4j_core" }
 langchain4j-kotlin = { group = "dev.langchain4j", name = "langchain4j-kotlin", version.ref = "langchain4j_kotlin" }
 langchain4j-anthropic = { group = "dev.langchain4j", name = "langchain4j-anthropic", version.ref = "langchain4j_anthropic" }
+langchain4j-openai = { group = "dev.langchain4j", name = "langchain4j-open-ai", version.ref = "langchain4j_openai" }
+langchain4j-google-ai-gemini = { group = "dev.langchain4j", name = "langchain4j-google-ai-gemini", version.ref = "langchain4j_google_ai_gemini" }
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -5,18 +5,20 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
-import io.qent.sona.core.State
-import io.qent.sona.core.StateProvider
-import io.qent.sona.core.Tools
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel
+import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel
+import io.qent.sona.core.*
 import io.qent.sona.repositories.PluginChatRepository
 import io.qent.sona.repositories.PluginRolesRepository
 import io.qent.sona.repositories.PluginSettingsRepository
+import io.qent.sona.repositories.PluginPresetsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.net.ssl.*
@@ -26,19 +28,37 @@ import javax.net.ssl.*
 class PluginStateFlow(private val project: Project) : Flow<State> {
 
     private val settingsRepository = service<PluginSettingsRepository>()
+    private val presetsRepository = service<PluginPresetsRepository>()
     private val chatRepository = service<PluginChatRepository>()
     private val rolesRepository = service<PluginRolesRepository>()
     private val scope = CoroutineScope(Dispatchers.Default)
     private val stateProvider = StateProvider(
-        settingsRepository,
+        presetsRepository,
         chatRepository,
         rolesRepository,
-        modelFactory = { settings ->
-            AnthropicStreamingChatModel.builder()
-                .apiKey(settings.apiKey)
-                .baseUrl(settings.apiEndpoint)
-                .modelName(settings.model)
-                .build()
+        modelFactory = { preset ->
+            when (preset.provider) {
+                LlmProvider.Anthropic -> AnthropicStreamingChatModel.builder()
+                    .apiKey(preset.apiKey)
+                    .baseUrl(preset.apiEndpoint)
+                    .modelName(preset.model)
+                    .build()
+                LlmProvider.OpenAI -> OpenAiStreamingChatModel.builder()
+                    .apiKey(preset.apiKey)
+                    .baseUrl(preset.apiEndpoint)
+                    .modelName(preset.model)
+                    .build()
+                LlmProvider.Deepseek -> OpenAiStreamingChatModel.builder()
+                    .apiKey(preset.apiKey)
+                    .baseUrl(preset.apiEndpoint)
+                    .modelName(preset.model)
+                    .build()
+                LlmProvider.Gemini -> GoogleAiGeminiStreamingChatModel.builder()
+                    .apiKey(preset.apiKey)
+                    .baseUrl(preset.apiEndpoint)
+                    .modelName(preset.model)
+                    .build()
+            }
         },
         tools = object : Tools {
             override fun getFocusedFileText(): String? {
@@ -60,6 +80,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
         onNewChat = {},
         onOpenHistory = {},
         onOpenRoles = {},
+        onOpenPresets = {},
     )
 
     init {
@@ -67,15 +88,19 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
             lastState = it
         }.launchIn(scope)
 
-        val trustAll: Array<TrustManager> = arrayOf(object : X509TrustManager {
-            override fun checkClientTrusted(c: Array<X509Certificate?>?, a: String?) = Unit
-            override fun checkServerTrusted(c: Array<X509Certificate?>?, a: String?) = Unit
-            override fun getAcceptedIssuers(): Array<X509Certificate?>? = arrayOfNulls(0)
-        })
-        val sc = SSLContext.getInstance("SSL")
-        sc.init(null, trustAll, SecureRandom())
-        HttpsURLConnection.setDefaultSSLSocketFactory(sc.socketFactory)
-        HttpsURLConnection.setDefaultHostnameVerifier { h: String?, s: SSLSession? -> true }
+        scope.launch {
+            if (settingsRepository.load().ignoreHttpsErrors) {
+                val trustAll: Array<TrustManager> = arrayOf(object : X509TrustManager {
+                    override fun checkClientTrusted(c: Array<X509Certificate?>?, a: String?) = Unit
+                    override fun checkServerTrusted(c: Array<X509Certificate?>?, a: String?) = Unit
+                    override fun getAcceptedIssuers(): Array<X509Certificate?>? = arrayOfNulls(0)
+                })
+                val sc = SSLContext.getInstance("SSL")
+                sc.init(null, trustAll, SecureRandom())
+                HttpsURLConnection.setDefaultSSLSocketFactory(sc.socketFactory)
+                HttpsURLConnection.setDefaultHostnameVerifier { _: String?, _: SSLSession? -> true }
+            }
+        }
     }
 
     override suspend fun collect(collector: FlowCollector<State>) {

--- a/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
+++ b/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
@@ -13,7 +13,9 @@ import com.intellij.ui.content.ContentFactory
 import io.qent.sona.core.State.ChatListState
 import io.qent.sona.core.State.ChatState
 import io.qent.sona.core.State.RolesState
+import io.qent.sona.core.State.PresetsState
 import io.qent.sona.ui.ChatPanel
+import io.qent.sona.ui.PresetsPanel
 import io.qent.sona.ui.RolesPanel
 import io.qent.sona.ui.SonaTheme
 import io.qent.sona.services.ThemeService
@@ -32,6 +34,7 @@ class PluginToolWindowFactory : ToolWindowFactory, DumbAware {
                         is ChatState -> ChatPanel(s)
                         is ChatListState -> ChatListPanel(s)
                         is RolesState -> RolesPanel(s)
+                        is PresetsState -> PresetsPanel(s)
                     }
                 }
             },
@@ -43,7 +46,8 @@ class PluginToolWindowFactory : ToolWindowFactory, DumbAware {
         toolWindow.setTitleActions(listOf(
             ActionManager.getInstance().getAction("CreateNewChatAction"),
             ActionManager.getInstance().getAction("OpenHistoryAction"),
-            ActionManager.getInstance().getAction("OpenRolesAction")
+            ActionManager.getInstance().getAction("OpenRolesAction"),
+            ActionManager.getInstance().getAction("OpenPresetsAction"),
         ))
     }
 }

--- a/src/main/kotlin/io/qent/sona/actions/CreateNewChatAction.kt
+++ b/src/main/kotlin/io/qent/sona/actions/CreateNewChatAction.kt
@@ -14,6 +14,7 @@ class CreateNewChatAction: AnAction("Create", "Create new chat", AllIcons.Genera
                 is State.ChatListState -> onNewChat()
                 is State.ChatState -> if (messages.isNotEmpty()) onNewChat()
                 is State.RolesState -> onNewChat()
+                is State.PresetsState -> onNewChat()
             }
         }
     }

--- a/src/main/kotlin/io/qent/sona/actions/OpenPresetsAction.kt
+++ b/src/main/kotlin/io/qent/sona/actions/OpenPresetsAction.kt
@@ -1,0 +1,13 @@
+package io.qent.sona.actions
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
+import io.qent.sona.PluginStateFlow
+
+class OpenPresetsAction : AnAction("Preset", "Edit LLM presets", AllIcons.General.Gear) {
+    override fun actionPerformed(e: AnActionEvent) {
+        e.project?.service<PluginStateFlow>()?.lastState?.onOpenPresets?.invoke()
+    }
+}

--- a/src/main/kotlin/io/qent/sona/repositories/PluginPresetsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginPresetsRepository.kt
@@ -1,0 +1,64 @@
+package io.qent.sona.repositories
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import io.qent.sona.core.*
+
+@Service
+@State(name = "PluginPresets", storages = [Storage("presets.xml")])
+class PluginPresetsRepository : PresetsRepository, PersistentStateComponent<PluginPresetsRepository.PluginPresetsState> {
+
+    data class StoredPreset(
+        var name: String = "",
+        var provider: String = LlmProvider.Anthropic.name,
+        var apiEndpoint: String = LlmProvider.Anthropic.defaultEndpoint,
+        var model: String = LlmProvider.Anthropic.models.first(),
+        var apiKey: String = "",
+    )
+
+    data class PluginPresetsState(
+        var active: Int = 0,
+        var presets: MutableList<StoredPreset> = mutableListOf(),
+    )
+
+    private var state = PluginPresetsState()
+
+    override fun getState(): PluginPresetsState = state
+
+    override fun loadState(state: PluginPresetsState) {
+        this.state = state
+    }
+
+    override suspend fun load(): Presets {
+        val presets = state.presets.map { stored ->
+            val provider = runCatching { LlmProvider.valueOf(stored.provider) }.getOrDefault(LlmProvider.Anthropic)
+            Preset(
+                stored.name,
+                provider,
+                stored.apiEndpoint.ifEmpty { provider.defaultEndpoint },
+                stored.model.ifEmpty { provider.models.first() },
+                stored.apiKey,
+            )
+        }
+        val active = state.active.coerceIn(0, (presets.size - 1).coerceAtLeast(0))
+        return Presets(active, presets)
+    }
+
+    override suspend fun save(presets: Presets) {
+        state = PluginPresetsState(
+            active = presets.active,
+            presets = presets.presets.map {
+                StoredPreset(
+                    name = it.name,
+                    provider = it.provider.name,
+                    apiEndpoint = it.apiEndpoint,
+                    model = it.model,
+                    apiKey = it.apiKey,
+                )
+            }.toMutableList()
+        )
+    }
+}
+

--- a/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
@@ -14,9 +14,7 @@ class PluginSettingsRepository :
     PersistentStateComponent<PluginSettingsRepository.PluginSettingsState>
 {
     data class PluginSettingsState(
-        var apiKey: String = "",
-        var apiEndpoint: String = "https://api.anthropic.com/v1/",
-        var model: String = "claude-3-5-haiku-20241022"
+        var ignoreHttpsErrors: Boolean = false,
     )
 
     private var pluginSettingsState = PluginSettingsState()
@@ -28,8 +26,6 @@ class PluginSettingsRepository :
     }
 
     override suspend fun load() = Settings(
-        pluginSettingsState.apiKey,
-        pluginSettingsState.apiEndpoint,
-        pluginSettingsState.model
+        pluginSettingsState.ignoreHttpsErrors,
     )
 }

--- a/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
@@ -1,77 +1,48 @@
 package io.qent.sona.settings
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.components.service
+import com.intellij.openapi.options.Configurable
 import io.qent.sona.repositories.PluginSettingsRepository
-import javax.swing.JComponent
-import org.jetbrains.jewel.bridge.JewelComposePanel
-import io.qent.sona.ui.SonaTheme
 import io.qent.sona.services.ThemeService
+import io.qent.sona.ui.SonaTheme
+import org.jetbrains.jewel.bridge.JewelComposePanel
+import org.jetbrains.jewel.ui.component.Checkbox
 import org.jetbrains.jewel.ui.component.Text
-import org.jetbrains.jewel.ui.component.TextField
 
 class PluginSettingsConfigurable : Configurable {
 
     private val repo = service<PluginSettingsRepository>()
+    private var currentIgnoreHttpsErrors = repo.state.ignoreHttpsErrors
 
-    private var currentApiKey = repo.state.apiKey
-    private var currentApiEndpoint = repo.state.apiEndpoint
-    private var currentModel = repo.state.model
-
-    override fun createComponent(): JComponent {
-        return JewelComposePanel {
-            val themeService = service<ThemeService>()
-            val dark by themeService.isDark.collectAsState()
-            val apiKey = rememberTextFieldState(currentApiKey)
-            val apiEndpoint = rememberTextFieldState(currentApiEndpoint)
-            val model = rememberTextFieldState(currentModel)
-
-            LaunchedEffect(apiKey.text) { currentApiKey = apiKey.text.toString() }
-            LaunchedEffect(apiEndpoint.text) { currentApiEndpoint = apiEndpoint.text.toString() }
-            LaunchedEffect(model.text) { currentModel = model.text.toString() }
-
-            SonaTheme(dark = dark) {
+    override fun createComponent() = JewelComposePanel {
+        val themeService = service<ThemeService>()
+        val dark by themeService.isDark.collectAsState()
+        var checked by remember { mutableStateOf(currentIgnoreHttpsErrors) }
+        LaunchedEffect(checked) { currentIgnoreHttpsErrors = checked }
+        SonaTheme(dark = dark) {
             Column(modifier = Modifier.width(600.dp).padding(16.dp)) {
-                Text("API Key")
-                TextField(
-                    apiKey,
-                    Modifier.fillMaxWidth()
-                )
-                Spacer(Modifier.height(8.dp))
-                Text("Endpoint")
-                TextField(apiEndpoint, Modifier.fillMaxWidth())
-                Spacer(Modifier.height(8.dp))
-                Text("Model")
-                TextField(model, Modifier.fillMaxWidth())
-                Spacer(Modifier.height(16.dp))
-            }
+                Row {
+                    Checkbox(checked = checked, onCheckedChange = { checked = it })
+                    Spacer(Modifier.width(8.dp))
+                    Text("Ignore HTTPS errors")
+                }
             }
         }
     }
 
     override fun isModified(): Boolean {
-        val savedState = repo.state
-        return currentApiKey != savedState.apiKey
-                || currentApiEndpoint != savedState.apiEndpoint
-                || currentModel != savedState.model
+        val saved = repo.state
+        return currentIgnoreHttpsErrors != saved.ignoreHttpsErrors
     }
 
     override fun apply() {
-        repo.loadState(
-            PluginSettingsRepository.PluginSettingsState(
-                currentApiKey,
-                currentApiEndpoint,
-                currentModel
-            )
-        )
+        repo.loadState(PluginSettingsRepository.PluginSettingsState(currentIgnoreHttpsErrors))
     }
 
     override fun getDisplayName(): String = "Sona"
 }
+

--- a/src/main/kotlin/io/qent/sona/ui/PresetsPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/PresetsPanel.kt
@@ -1,0 +1,147 @@
+package io.qent.sona.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.qent.sona.core.LlmProvider
+import io.qent.sona.core.Preset
+import io.qent.sona.core.State
+import org.jetbrains.jewel.ui.component.ActionButton
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.TextField
+
+@Composable
+fun PresetsPanel(state: State.PresetsState) {
+    val nameState = rememberTextFieldState(state.preset.name)
+    var provider by remember { mutableStateOf(state.preset.provider) }
+    var model by remember { mutableStateOf(state.preset.model) }
+    val apiState = rememberTextFieldState(state.preset.apiEndpoint)
+    val tokenState = rememberTextFieldState(state.preset.apiKey)
+
+    LaunchedEffect(state.preset) {
+        nameState.setTextAndPlaceCursorAtEnd(state.preset.name)
+        provider = state.preset.provider
+        model = state.preset.model
+        apiState.setTextAndPlaceCursorAtEnd(state.preset.apiEndpoint)
+        tokenState.setTextAndPlaceCursorAtEnd(state.preset.apiKey)
+    }
+
+    Box(
+        Modifier
+            .fillMaxSize()
+            .background(SonaTheme.colors.Background)
+    ) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(8.dp)
+        ) {
+            if (state.presets.isEmpty() || state.creating) {
+                PresetForm(nameState, provider, {
+                    provider = it
+                    model = it.models.first()
+                    apiState.setTextAndPlaceCursorAtEnd(it.defaultEndpoint)
+                }, model, { model = it }, apiState, tokenState)
+                Spacer(Modifier.height(8.dp))
+                ActionButton(onClick = {
+                    state.onAddPreset(
+                        Preset(
+                            nameState.text.toString(),
+                            provider,
+                            apiState.text.toString(),
+                            model,
+                            tokenState.text.toString()
+                        )
+                    )
+                }, modifier = Modifier.fillMaxWidth()) { Text("Save") }
+            } else {
+                Row(Modifier.fillMaxWidth()) {
+                    DropdownSelector(
+                        items = state.presets,
+                        selectedIndex = state.currentIndex,
+                        expandUpwards = false,
+                        onSelect = { state.onSelectPreset(it) },
+                        modifier = Modifier.weight(1f),
+                        backgroundColor = SonaTheme.colors.Background,
+                        buttonModifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    ActionButton(onClick = {
+                        nameState.clearText()
+                        tokenState.clearText()
+                        state.onStartCreatePreset()
+                    }) { Text("+") }
+                    Spacer(Modifier.width(8.dp))
+                    ActionButton(onClick = { state.onDeletePreset() }) { Text("\uD83D\uDDD1") }
+                }
+                Spacer(Modifier.height(8.dp))
+                PresetForm(nameState, provider, {
+                    provider = it
+                    model = it.models.first()
+                    apiState.setTextAndPlaceCursorAtEnd(it.defaultEndpoint)
+                }, model, { model = it }, apiState, tokenState)
+                Spacer(Modifier.height(8.dp))
+                ActionButton(onClick = {
+                    state.onSave(
+                        Preset(
+                            nameState.text.toString(),
+                            provider,
+                            apiState.text.toString(),
+                            model,
+                            tokenState.text.toString()
+                        )
+                    )
+                }, modifier = Modifier.fillMaxWidth()) { Text("Save") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PresetForm(
+    nameState: androidx.compose.foundation.text.input.TextFieldState,
+    provider: LlmProvider,
+    onProviderChange: (LlmProvider) -> Unit,
+    model: String,
+    onModelChange: (String) -> Unit,
+    apiState: androidx.compose.foundation.text.input.TextFieldState,
+    tokenState: androidx.compose.foundation.text.input.TextFieldState
+) {
+    Column(Modifier.fillMaxWidth()) {
+        Text("Name")
+        TextField(nameState, Modifier.fillMaxWidth())
+        Spacer(Modifier.height(8.dp))
+        Text("Provider")
+        DropdownSelector(
+            items = LlmProvider.entries.map { it.name },
+            selectedIndex = LlmProvider.entries.indexOf(provider),
+            expandUpwards = false,
+            onSelect = { idx -> onProviderChange(LlmProvider.entries[idx]) },
+            modifier = Modifier.fillMaxWidth(),
+            backgroundColor = SonaTheme.colors.Background,
+            buttonModifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        Text("Model")
+        DropdownSelector(
+            items = provider.models,
+            selectedIndex = provider.models.indexOf(model).coerceAtLeast(0),
+            expandUpwards = false,
+            onSelect = { idx -> onModelChange(provider.models[idx]) },
+            modifier = Modifier.fillMaxWidth(),
+            backgroundColor = SonaTheme.colors.Background,
+            buttonModifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        Text("API URL")
+        TextField(apiState, Modifier.fillMaxWidth())
+        Spacer(Modifier.height(8.dp))
+        Text("Token")
+        TextField(tokenState, Modifier.fillMaxWidth())
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,12 @@
                 text="Role"
                 description="Edit system message"
                 icon="AllIcons.General.User"/>
+
+        <action id="OpenPresetsAction"
+                class="io.qent.sona.actions.OpenPresetsAction"
+                text="Preset"
+                description="Edit LLM presets"
+                icon="AllIcons.General.Gear"/>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">
@@ -44,6 +50,7 @@
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginSettingsRepository"/>
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginChatRepository"/>
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginRolesRepository"/>
+        <applicationService serviceImplementation="io.qent.sona.repositories.PluginPresetsRepository"/>
         <applicationService serviceImplementation="io.qent.sona.services.ThemeService"/>
 
         <applicationConfigurable


### PR DESCRIPTION
## Summary
- support multiple LLM providers via presets
- add presets management UI and toolbar action
- simplify settings to Ignore HTTPS errors checkbox

## Testing
- `./gradlew build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688f0267c1e083209bc42533de7ee001