### PR TITLE
Make default roles undeletable and adjust chat placeholder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@
 - Settings are stored using a repository interface in the logic module with an IntelliJ implementation in the UI module.
 - Chat history is persisted via a repository implementation (`PluginChatRepository`) that stores chats across IDE
   sessions.
-- System prompts (roles) are stored in `RolesRepository` and can be managed from
-  the Roles screen. Each role has a name and text and the last role cannot be
-  deleted.
+  - System prompts (roles) are stored in `RolesRepository` and can be managed from
+    the Roles screen. Each role has a name and text. The default Architect and
+    Coder roles cannot be deleted.
 - LLM connection details are organised as presets via `PresetsRepository`. At least one preset must exist for the chat
   to work and they are managed from the Presets screen.
 - Plugin settings contain only the "Ignore HTTPS errors" flag which, when enabled, trusts all HTTPS certificates.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ branch during the previous day. The resulting archive is uploaded as a workflow 
 
 The plugin supports multiple system roles. Open the roles screen from the tool
 window actions to switch between roles or create new ones. Each role has its own
-prompt text. Roles can be added, selected and removed (except the last role).
-The active role can also be changed directly from the chat via the selector
-under the message input. The text of the active role is sent as a system
-message with every request but is not stored in the chat history.
+prompt text. Roles can be added, selected and removed, but the default Architect
+and Coder roles cannot be deleted. The active role can also be changed directly
+from the chat via the selector under the message input. The text of the active
+role is sent as a system message with every request but is not stored in the
+chat history.
+
+When starting a new conversation the message field shows a placeholder tailored
+to the active role. The Architect role suggests planning and design, the Coder
+role suggests implementation, and other roles display a generic "Describe your
+task..." prompt. Once messages are present, the placeholder becomes
+"Type a message...".
 
 ## Presets
 

--- a/core/src/main/kotlin/io/qent/sona/core/DefaultRoles.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/DefaultRoles.kt
@@ -1,0 +1,7 @@
+package io.qent.sona.core
+
+object DefaultRoles {
+    const val ARCHITECT = "\uD83C\uDFD7\uFE0F  Architect"
+    const val CODER = "\uD83D\uDCBB  Coder"
+    val NAMES = setOf(ARCHITECT, CODER)
+}

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -167,7 +167,8 @@ class StateProvider(
     }
 
     private suspend fun deleteRole() {
-        if (roles.roles.size <= 1) return
+        val currentName = roles.roles[roles.active].name
+        if (currentName in DefaultRoles.NAMES) return
         val list = roles.roles.toMutableList()
         list.removeAt(roles.active)
         val newActive = roles.active.coerceAtMost(list.lastIndex)

--- a/src/main/kotlin/io/qent/sona/repositories/PluginRolesRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginRolesRepository.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.components.Storage
 import io.qent.sona.core.Role
 import io.qent.sona.core.Roles
 import io.qent.sona.core.RolesRepository
+import io.qent.sona.core.DefaultRoles
 
 @Service
 @State(name = "PluginRoles", storages = [Storage("roles.xml")])
@@ -21,11 +22,11 @@ class PluginRolesRepository : RolesRepository, PersistentStateComponent<PluginRo
         var roles: MutableList<StoredRole> = mutableListOf(
             // https://github.com/RooCodeInc/Roo-Code/blob/main/packages/types/src/mode.ts
             StoredRole(
-                "\uD83C\uDFD7\uFE0F  Architect",
+                DefaultRoles.ARCHITECT,
                 "You are Roo, an experienced technical leader who is inquisitive and an excellent planner. Your goal is to gather information and get context to create a detailed plan for accomplishing the user's task, which the user will review and approve before they switch into another mode to implement the solution."
             ),
             StoredRole(
-                "\uD83D\uDCBB  Code",
+                DefaultRoles.CODER,
                 "You are Roo, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices."
             )
         )

--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.qent.sona.core.DefaultRoles
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.model.rememberMarkdownState
 import dev.langchain4j.data.message.AiMessage
@@ -141,6 +142,15 @@ fun AiAvatar() {
 private fun Input(state: ChatState) {
     val text = remember { mutableStateOf("") }
     var isFocused by remember { mutableStateOf(false) }
+    val placeholder = if (state.messages.isNotEmpty()) {
+        "Type a message..."
+    } else {
+        when (state.roles[state.activeRole]) {
+            DefaultRoles.ARCHITECT -> "Describe what you'd like to plan and design..."
+            DefaultRoles.CODER -> "Describe what you'd like to implement..."
+            else -> "Describe your task..."
+        }
+    }
 
 
     Box(
@@ -166,7 +176,7 @@ private fun Input(state: ChatState) {
             ) {
                 if (text.value.isEmpty()) {
                     Text(
-                        "Напишите сообщение...",
+                        placeholder,
                         color = SonaTheme.colors.Placeholder,
                         fontSize = 14.sp
                     )

--- a/src/main/kotlin/io/qent/sona/ui/RolesPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/RolesPanel.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import io.qent.sona.core.DefaultRoles
 import io.qent.sona.core.State.RolesState
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
@@ -69,7 +70,8 @@ fun RolesPanel(state: RolesState) {
                     Spacer(Modifier.width(8.dp))
                     ActionButton(
                         onClick = { state.onDeleteRole() },
-                        enabled = state.roles.size > 1
+                        enabled = state.roles.size > DefaultRoles.NAMES.size &&
+                            state.roles[state.currentIndex] !in DefaultRoles.NAMES
                     ) { Text("\uD83D\uDDD1") }
                 }
             }

--- a/src/main/kotlin/io/qent/sona/ui/Utils.kt
+++ b/src/main/kotlin/io/qent/sona/ui/Utils.kt
@@ -8,6 +8,6 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun Dp.dp2int(): Int {
     val density = LocalDensity.current
-    val verticalPadding = 6.dp // Твой vertical padding
+    val verticalPadding = 6.dp // Your vertical padding
     return with(density) { verticalPadding.toPx() }.toInt()
 }


### PR DESCRIPTION
## Summary
- protect default Architect and Coder roles from deletion
- add role-based placeholder suggestions in chat input
- translate remaining Russian UI text to English

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688f5975947883209b5cdaa67e5abb75