### PR TITLE
feat: allow agent role switching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,12 @@
   sessions.
   - System prompts (roles) are stored in `RolesRepository` and can be managed from
     the Roles screen. Each role has a name and text. The default Architect and
-    Coder roles cannot be deleted.
+    Code roles cannot be deleted.
 - LLM connection details are organised as presets via `PresetsRepository`. At least one preset must exist for the chat
   to work and they are managed from the Presets screen.
 - Plugin settings contain only the "Ignore HTTPS errors" flag which, when enabled, trusts all HTTPS certificates.
 - Each chat tracks tools approved by the user so that previously allowed tools run without asking again.
+- A tool is available to switch the active role between Architect and Code.
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ branch during the previous day. The resulting archive is uploaded as a workflow 
 The plugin supports multiple system roles. Open the roles screen from the tool
 window actions to switch between roles or create new ones. Each role has its own
 prompt text. Roles can be added, selected and removed, but the default Architect
-and Coder roles cannot be deleted. The active role can also be changed directly
+and Code roles cannot be deleted. The active role can also be changed directly
 from the chat via the selector under the message input. The text of the active
 role is sent as a system message with every request but is not stored in the
 chat history.
 
+Models can also switch roles themselves using tools to toggle between Architect and Code.
+
 When starting a new conversation the message field shows a placeholder tailored
-to the active role. The Architect role suggests planning and design, the Coder
+to the active role. The Architect role suggests planning and design, the Code
 role suggests implementation, and other roles display a generic "Describe your
 task..." prompt. Once messages are present, the placeholder becomes
 "Type a message...".
@@ -50,6 +52,8 @@ it to trust all HTTPS certificates when connecting to custom endpoints.
 When the model requests to run a tool, the plugin asks for permission before
 executing it. You can allow the action once or choose **Always in this chat** to
 skip future confirmations for the same tool within the current conversation.
+
+The available tools let the model read the focused file and switch the active role between Architect and Code.
 
 ## Architecture Overview
 

--- a/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
@@ -117,6 +117,18 @@ class ChatFlow(
                                 tools.getFocusedFileText()
                             )
 
+                            "switchToArchitect" -> ToolExecutionResultMessage(
+                                toolRequest.id(),
+                                toolName,
+                                tools.switchToArchitect()
+                            )
+
+                            "switchToCode" -> ToolExecutionResultMessage(
+                                toolRequest.id(),
+                                toolName,
+                                tools.switchToCode()
+                            )
+
                             else -> throw IllegalArgumentException()
                         }
                     } else {

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -167,6 +167,13 @@ class StateProvider(
         _state.emit(createChatState(currentChat))
     }
 
+    suspend fun selectRoleByName(name: String) {
+        val idx = roles.roles.indexOfFirst { it.name == name }
+        if (idx >= 0) {
+            selectChatRole(idx)
+        }
+    }
+
     private suspend fun startCreateRole() {
         creatingRole = true
         _state.emit(createRolesState())

--- a/core/src/main/kotlin/io/qent/sona/core/Tools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/Tools.kt
@@ -2,4 +2,6 @@ package io.qent.sona.core
 
 interface Tools {
     fun getFocusedFileText(): String?
+    fun switchToArchitect(): String
+    fun switchToCode(): String
 }

--- a/core/src/main/kotlin/io/qent/sona/core/ToolsInfoDecorator.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ToolsInfoDecorator.kt
@@ -6,4 +6,10 @@ class ToolsInfoDecorator(private val tools: Tools) : Tools {
 
     @Tool("Return source of file opened at current focused editor")
     override fun getFocusedFileText() = tools.getFocusedFileText()
+
+    @Tool("Switch agent role to Architect")
+    override fun switchToArchitect() = tools.switchToArchitect()
+
+    @Tool("Switch agent role to Code")
+    override fun switchToCode() = tools.switchToCode()
 }

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -32,43 +32,23 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
     private val chatRepository = service<PluginChatRepository>()
     private val rolesRepository = service<PluginRolesRepository>()
     private val scope = CoroutineScope(Dispatchers.Default)
-    private val stateProvider = StateProvider(
-        presetsRepository,
-        chatRepository,
-        rolesRepository,
-        modelFactory = { preset ->
-            when (preset.provider) {
-                LlmProvider.Anthropic -> AnthropicStreamingChatModel.builder()
-                    .apiKey(preset.apiKey)
-                    .baseUrl(preset.apiEndpoint)
-                    .modelName(preset.model)
-                    .build()
+    private lateinit var stateProvider: StateProvider
 
-                LlmProvider.OpenAI -> OpenAiStreamingChatModel.builder()
-                    .apiKey(preset.apiKey)
-                    .baseUrl(preset.apiEndpoint)
-                    .modelName(preset.model)
-                    .build()
+    private val tools = object : Tools {
+        override fun getFocusedFileText(): String? {
+            return FileEditorManager.getInstance(project).selectedTextEditor?.document?.text
+        }
 
-                LlmProvider.Deepseek -> OpenAiStreamingChatModel.builder()
-                    .apiKey(preset.apiKey)
-                    .baseUrl(preset.apiEndpoint)
-                    .modelName(preset.model)
-                    .build()
+        override fun switchToArchitect(): String {
+            scope.launch { stateProvider.selectRoleByName(DefaultRoles.ARCHITECT) }
+            return "Architect mode active"
+        }
 
-                LlmProvider.Gemini -> GoogleAiGeminiStreamingChatModel.builder()
-                    .apiKey(preset.apiKey)
-                    .baseUrl(preset.apiEndpoint)
-                    .modelName(preset.model)
-                    .build()
-            }
-        },
-        tools = object : Tools {
-            override fun getFocusedFileText(): String? {
-                return FileEditorManager.getInstance(project).selectedTextEditor?.document?.text
-            }
-        }, scope = scope
-    )
+        override fun switchToCode(): String {
+            scope.launch { stateProvider.selectRoleByName(DefaultRoles.CODE) }
+            return "Code mode active"
+        }
+    }
 
     var lastState: State = State.ChatState(
         messages = emptyList(),
@@ -93,6 +73,41 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
     )
 
     init {
+        stateProvider = StateProvider(
+            presetsRepository,
+            chatRepository,
+            rolesRepository,
+            modelFactory = { preset ->
+                when (preset.provider) {
+                    LlmProvider.Anthropic -> AnthropicStreamingChatModel.builder()
+                        .apiKey(preset.apiKey)
+                        .baseUrl(preset.apiEndpoint)
+                        .modelName(preset.model)
+                        .build()
+
+                    LlmProvider.OpenAI -> OpenAiStreamingChatModel.builder()
+                        .apiKey(preset.apiKey)
+                        .baseUrl(preset.apiEndpoint)
+                        .modelName(preset.model)
+                        .build()
+
+                    LlmProvider.Deepseek -> OpenAiStreamingChatModel.builder()
+                        .apiKey(preset.apiKey)
+                        .baseUrl(preset.apiEndpoint)
+                        .modelName(preset.model)
+                        .build()
+
+                    LlmProvider.Gemini -> GoogleAiGeminiStreamingChatModel.builder()
+                        .apiKey(preset.apiKey)
+                        .baseUrl(preset.apiEndpoint)
+                        .modelName(preset.model)
+                        .build()
+                }
+            },
+            tools = tools,
+            scope = scope,
+        )
+
         stateProvider.state.onEach {
             lastState = it
         }.launchIn(scope)


### PR DESCRIPTION
## Summary
- expose agent tools to toggle Architect and Code roles
- add core support for switching roles via tool requests
- document new role-switching tools and default "Code" role name

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688fa32e501c832089b6df3a69133732