### PR TITLE
Add per-message deletion via trash icon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Settings are stored using a repository interface in the logic module with an IntelliJ implementation in the UI module.
 - Chat history is persisted via a repository implementation (`PluginChatRepository`) that stores chats across IDE
   sessions.
+  - Individual messages can be removed via a trash icon. Deleting a message truncates the chat history from that point.
   - System prompts (roles) are stored in `RolesRepository` and can be managed from
     the Roles screen. Each role has a name and text. The default Architect and
     Coder roles cannot be deleted.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ When the model requests to run a tool, the plugin asks for permission before
 executing it. You can allow the action once or choose **Always in this chat** to
 skip future confirmations for the same tool within the current conversation.
 
+## Deleting messages
+
+Each message has a trash icon in its top‑right corner. Clicking it removes that
+message and all following messages from both the chat view and persistent
+history.
+
 ## Architecture Overview
 
 The project is split into two modules:

--- a/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
@@ -242,6 +242,13 @@ class ChatFlow(
         }
     }
 
+    suspend fun deleteFrom(index: Int) {
+        stop()
+        val chatId = currentState.chatId
+        chatRepository.deleteMessagesFrom(chatId, index)
+        loadChat(chatId)
+    }
+
     fun stop() {
         currentContinuation?.cancel()
         currentContinuation = null

--- a/core/src/main/kotlin/io/qent/sona/core/ChatRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatRepository.kt
@@ -35,6 +35,9 @@ interface ChatRepository {
 
     /** Delete chat with all messages. */
     suspend fun deleteChat(chatId: String)
+
+    /** Delete all messages in [chatId] starting from [index]. */
+    suspend fun deleteMessagesFrom(chatId: String, index: Int)
 }
 
 data class ChatRepositoryMessage(

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -20,6 +20,7 @@ sealed class State {
         val onSelectPreset: (Int) -> Unit,
         val onSendMessage: (String) -> Unit,
         val onStop: () -> Unit,
+        val onDeleteFrom: (Int) -> Unit,
         val toolRequest: Boolean,
         val onAllowTool: () -> Unit,
         val onAlwaysAllowTool: () -> Unit,

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -77,6 +77,7 @@ class StateProvider(
         onSelectPreset = { idx -> scope.launch { selectChatPreset(idx) } },
         onSendMessage = { text -> scope.launch { send(text) } },
         onStop = { scope.launch { stop() } },
+        onDeleteFrom = { idx -> scope.launch { deleteFrom(idx) } },
         toolRequest = chat.toolRequest != null,
         onAllowTool = { scope.launch { chatFlow.resolveToolPermission(true, false) } },
         onAlwaysAllowTool = { scope.launch { chatFlow.resolveToolPermission(true, true) } },
@@ -204,6 +205,7 @@ class StateProvider(
 
     private suspend fun send(text: String) = chatFlow.send(text)
     private fun stop() = chatFlow.stop()
+    private suspend fun deleteFrom(idx: Int) = chatFlow.deleteFrom(idx)
 
     private fun createPresetsState(): State.PresetsState {
         val preset = if (creatingPreset || presets.presets.isEmpty()) {

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -82,6 +82,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
         onSelectPreset = {},
         onSendMessage = {},
         onStop = {},
+        onDeleteFrom = {},
         toolRequest = false,
         onAllowTool = {},
         onAlwaysAllowTool = {},

--- a/src/main/kotlin/io/qent/sona/repositories/PluginChatRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginChatRepository.kt
@@ -105,4 +105,11 @@ class PluginChatRepository : ChatRepository, PersistentStateComponent<PluginChat
     override suspend fun deleteChat(chatId: String) {
         state.chats.removeIf { it.id == chatId }
     }
+
+    override suspend fun deleteMessagesFrom(chatId: String, index: Int) {
+        val chat = findChat(chatId)
+        if (index < chat.messages.size) {
+            chat.messages.subList(index, chat.messages.size).clear()
+        }
+    }
 }

--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -3,6 +3,7 @@ package io.qent.sona.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -78,9 +79,9 @@ private fun Messages(state: ChatState, modifier: Modifier = Modifier) {
                     val bottom: (@Composable () -> Unit)? = if (state.toolRequest && index == state.messages.lastIndex) {
                         @Composable { ToolPermissionButtons(state.onAllowTool, state.onAlwaysAllowTool, state.onDenyTool) }
                     } else null
-                    MessageBubble(message, isUser = false, bottomContent = bottom)
+                    MessageBubble(message, isUser = false, bottomContent = bottom, onDelete = { state.onDeleteFrom(index) })
                 } else if (message is UserMessage) {
-                    MessageBubble(message, isUser = true)
+                    MessageBubble(message, isUser = true, onDelete = { state.onDeleteFrom(index) })
                 }
             }
             Spacer(Modifier.height(2.dp))
@@ -94,7 +95,7 @@ private fun Messages(state: ChatState, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun MessageBubble(message: Any, isUser: Boolean, bottomContent: (@Composable () -> Unit)? = null) {
+fun MessageBubble(message: Any, isUser: Boolean, bottomContent: (@Composable () -> Unit)? = null, onDelete: () -> Unit) {
     if (message is AiMessage) {
         if (message.text().isNullOrEmpty()) return
     }
@@ -134,6 +135,11 @@ fun MessageBubble(message: Any, isUser: Boolean, bottomContent: (@Composable () 
                 it()
             }
         }
+        Text(
+            "🗑",
+            color = textColor,
+            modifier = Modifier.align(Alignment.TopEnd).clickable(onClick = onDelete)
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- add trash icon to each chat bubble and allow truncating conversation from that point
- support message truncation in chat flow and repository
- document message deletion capability

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688fa36d4bf883209016446211ee58cf