### PR TITLE
Add message copy button and hover actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Settings are stored using a repository interface in the logic module with an IntelliJ implementation in the UI module.
 - Chat history is persisted via a repository implementation (`PluginChatRepository`) that stores chats across IDE
   sessions.
-  - Individual messages can be removed via a trash icon. Deleting a message truncates the chat history from that point.
+  - Individual messages can be copied via a clipboard icon or removed via a trash icon. Deleting a message truncates the chat history from that point.
   - System prompts (roles) are stored in `RolesRepository` and can be managed from
     the Roles screen. Each role has a name and text. The default Architect and
     Code roles cannot be deleted.

--- a/README.md
+++ b/README.md
@@ -55,11 +55,15 @@ skip future confirmations for the same tool within the current conversation.
 
 The available tools let the model read the focused file and switch the active role between Architect and Code.
 
-## Deleting messages
+## Copying and deleting messages
 
-Each message has a trash icon in its top‑right corner. Clicking it removes that
-message and all following messages from both the chat view and persistent
+When hovering a message its top‑right corner reveals copy and delete icons.
+The clipboard button copies the entire message text while the trash icon removes
+that message and all following messages from both the chat view and persistent
 history.
+
+Chat messages are now selectable so you can highlight and copy any portion of
+the text directly.
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary
- allow copying message text via new clipboard icon and show actions on hover
- enable text selection inside chat messages
- document copy/delete behavior in README and guidelines

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688fb77cb270832092ce3fe3bc288062