### PR TITLE
feat: add hover actions for chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The available tools let the model read the focused file and switch the active ro
 
 ## Copying and deleting messages
 
-When hovering a message its top‑right corner reveals copy and delete icons.
+When hovering a message, copy and delete icons appear beneath its bottom‑right corner.
 The clipboard button copies the entire message text while the trash icon removes
 that message and all following messages from both the chat view and persistent
 history.

--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -3,6 +3,7 @@ package io.qent.sona.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -19,9 +20,11 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.input.pointer.pointerMoveFilter
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
@@ -113,7 +116,7 @@ fun MessageBubble(message: Any, isUser: Boolean, bottomContent: (@Composable () 
         is UserMessage -> message.singleText().trim()
         else -> ""
     }
-    Box(
+    Column(
         Modifier
             .pointerMoveFilter(
                 onEnter = {
@@ -125,48 +128,61 @@ fun MessageBubble(message: Any, isUser: Boolean, bottomContent: (@Composable () 
                     false
                 }
             )
-            .shadow(if (hovered) 6.dp else 2.dp, RoundedCornerShape(14.dp))
-            .background(background, RoundedCornerShape(14.dp))
-            .padding(horizontal = 12.dp, vertical = 8.dp)
             .widthIn(max = 420.dp)
     ) {
-        SelectionContainer {
-            Column(Modifier.fillMaxWidth()) {
-                if (message is AiMessage) {
-                    val mdState = rememberMarkdownState(message.text(), immediate = true)
-                    Markdown(
-                        mdState,
-                        colors = SonaTheme.markdownColors,
-                        typography = SonaTheme.markdownTypography,
-                    )
-                } else if (message is UserMessage) {
-                    Text(
-                        message.singleText().trim(),
-                        color = textColor,
-                        fontSize = 15.sp
-                    )
-                }
-                bottomContent?.let {
-                    Spacer(Modifier.height(8.dp))
-                    it()
+        Box(
+            Modifier
+                .shadow(if (hovered) 6.dp else 2.dp, RoundedCornerShape(14.dp))
+                .background(background, RoundedCornerShape(14.dp))
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .fillMaxWidth()
+        ) {
+            SelectionContainer {
+                Column(Modifier.fillMaxWidth()) {
+                    if (message is AiMessage) {
+                        val mdState = rememberMarkdownState(message.text(), immediate = true)
+                        Markdown(
+                            mdState,
+                            colors = SonaTheme.markdownColors,
+                            typography = SonaTheme.markdownTypography,
+                        )
+                    } else if (message is UserMessage) {
+                        Text(
+                            message.singleText().trim(),
+                            color = textColor,
+                            fontSize = 15.sp
+                        )
+                    }
+                    bottomContent?.let {
+                        Spacer(Modifier.height(8.dp))
+                        it()
+                    }
                 }
             }
         }
         Row(
-            modifier = Modifier.align(Alignment.TopEnd).alpha(if (hovered) 1f else 0f),
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp)
+                .alpha(if (hovered) 1f else 0f),
+            horizontalArrangement = Arrangement.End,
         ) {
-            Text(
-                "\uD83D\uDCCB",
-                color = textColor,
-                modifier = Modifier.clickable {
-                    clipboard.setText(AnnotatedString(messageText))
-                }
+            Image(
+                painter = painterResource("icons/copy.svg"),
+                contentDescription = "Copy message",
+                colorFilter = ColorFilter.tint(textColor),
+                modifier = Modifier
+                    .size(16.dp)
+                    .clickable { clipboard.setText(AnnotatedString(messageText)) }
             )
-            Text(
-                "\uD83D\uDDD1",
-                color = textColor,
-                modifier = Modifier.clickable(onClick = onDelete)
+            Spacer(Modifier.width(4.dp))
+            Image(
+                painter = painterResource("icons/trash.svg"),
+                contentDescription = "Delete message",
+                colorFilter = ColorFilter.tint(textColor),
+                modifier = Modifier
+                    .size(16.dp)
+                    .clickable(onClick = onDelete)
             )
         }
     }

--- a/src/main/resources/icons/copy.svg
+++ b/src/main/resources/icons/copy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+</svg>

--- a/src/main/resources/icons/trash.svg
+++ b/src/main/resources/icons/trash.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3 6 5 6 21 6"/>
+  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+  <path d="M10 11v6"/>
+  <path d="M14 11v6"/>
+  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+</svg>


### PR DESCRIPTION
## Summary
- use vector copy and delete icons that appear on hover beneath messages
- mention bottom-right icons in README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688fbe59059083209d79e17322f76c50