### PR TITLE
Split tools interfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,10 @@ IDE theme changes.
   the Compose UI and `PluginStateFlow`, a project service exposing
   `StateFlow<State>` from `StateProvider`.
 
-`Tools` are injected into `ChatFlow` through an interface so that IDE specific
-helpers can be implemented in the plugin module.
+`ExternalTools` are implemented in the plugin module using the IntelliJ
+API while `InternalTools` live in the core module for plugin interactions like
+switching roles. The `Tools` interface extends both and is injected into
+`ChatFlow` via a core implementation that delegates to the two sets of tools.
 
 Whenever you extend the logic make sure the flow of state remains unidirectional
 and that the core module stays free from IntelliJ SDK imports.

--- a/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
@@ -32,12 +32,13 @@ class ChatFlow(
     private val rolesRepository: RolesRepository,
     private val chatRepository: ChatRepository,
     private val modelFactory: (Preset) -> StreamingChatModel,
-    tools: Tools,
+    internalTools: InternalTools,
+    externalTools: ExternalTools,
     scope: CoroutineScope,
 ) : Flow<Chat> {
 
     private val scope = scope + Dispatchers.IO
-    private val tools = ToolsInfoDecorator(tools)
+    private val tools = ToolsInfoDecorator(internalTools, externalTools)
 
     private val mutableSharedState = MutableSharedFlow<Chat>()
     private var currentState = Chat("", TokenUsage(0, 0))

--- a/core/src/main/kotlin/io/qent/sona/core/DefaultInternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/DefaultInternalTools.kt
@@ -1,0 +1,20 @@
+package io.qent.sona.core
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class DefaultInternalTools(
+    private val scope: CoroutineScope,
+    private val selectRole: suspend (DefaultRoles) -> Unit,
+) : InternalTools {
+
+    override fun switchToArchitect(): String {
+        scope.launch { selectRole(DefaultRoles.ARCHITECT) }
+        return "Architect mode active"
+    }
+
+    override fun switchToCode(): String {
+        scope.launch { selectRole(DefaultRoles.CODE) }
+        return "Code mode active"
+    }
+}

--- a/core/src/main/kotlin/io/qent/sona/core/ExternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ExternalTools.kt
@@ -1,0 +1,5 @@
+package io.qent.sona.core
+
+interface ExternalTools {
+    fun getFocusedFileText(): String?
+}

--- a/core/src/main/kotlin/io/qent/sona/core/InternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/InternalTools.kt
@@ -1,0 +1,6 @@
+package io.qent.sona.core
+
+interface InternalTools {
+    fun switchToArchitect(): String
+    fun switchToCode(): String
+}

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -13,11 +13,12 @@ class StateProvider(
     private val chatRepository: ChatRepository,
     private val rolesRepository: RolesRepository,
     modelFactory: (Preset) -> StreamingChatModel,
-    tools: Tools,
+    externalTools: ExternalTools,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 ) {
 
-    private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, tools, scope)
+    private val internalTools = DefaultInternalTools(scope, ::selectRole)
+    private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, internalTools, externalTools, scope)
 
     private val _state = MutableSharedFlow<State>(replay = 1)
 

--- a/core/src/main/kotlin/io/qent/sona/core/Tools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/Tools.kt
@@ -1,7 +1,3 @@
 package io.qent.sona.core
 
-interface Tools {
-    fun getFocusedFileText(): String?
-    fun switchToArchitect(): String
-    fun switchToCode(): String
-}
+interface Tools : InternalTools, ExternalTools

--- a/core/src/main/kotlin/io/qent/sona/core/ToolsInfoDecorator.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ToolsInfoDecorator.kt
@@ -2,14 +2,17 @@ package io.qent.sona.core
 
 import dev.langchain4j.agent.tool.Tool
 
-class ToolsInfoDecorator(private val tools: Tools) : Tools {
+class ToolsInfoDecorator(
+    private val internalTools: InternalTools,
+    private val externalTools: ExternalTools,
+) : Tools {
 
     @Tool("Return source of file opened at current focused editor")
-    override fun getFocusedFileText() = tools.getFocusedFileText()
+    override fun getFocusedFileText() = externalTools.getFocusedFileText()
 
     @Tool("Switch agent role to Architect")
-    override fun switchToArchitect() = tools.switchToArchitect()
+    override fun switchToArchitect() = internalTools.switchToArchitect()
 
     @Tool("Switch agent role to Code")
-    override fun switchToCode() = tools.switchToCode()
+    override fun switchToCode() = internalTools.switchToCode()
 }

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -2,12 +2,12 @@ package io.qent.sona
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
 import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import io.qent.sona.core.*
+import io.qent.sona.tools.PluginExternalTools
 import io.qent.sona.repositories.PluginChatRepository
 import io.qent.sona.repositories.PluginPresetsRepository
 import io.qent.sona.repositories.PluginRolesRepository
@@ -34,25 +34,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
     private val scope = CoroutineScope(Dispatchers.Default)
     private var stateProvider: StateProvider
 
-    private val tools = object : Tools {
-        override fun getFocusedFileText(): String? {
-            return FileEditorManager.getInstance(project).selectedTextEditor?.document?.text
-        }
-
-        override fun switchToArchitect(): String {
-            scope.launch {
-                stateProvider.selectRole(DefaultRoles.ARCHITECT)
-            }
-            return "Architect mode active"
-        }
-
-        override fun switchToCode(): String {
-            scope.launch {
-                stateProvider.selectRole(DefaultRoles.CODE)
-            }
-            return "Code mode active"
-        }
-    }
+    private val externalTools = PluginExternalTools(project)
 
     var lastState: State = State.ChatState(
         messages = emptyList(),
@@ -109,7 +91,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
                         .build()
                 }
             },
-            tools = tools,
+            externalTools = externalTools,
             scope = scope,
         )
 

--- a/src/main/kotlin/io/qent/sona/tools/PluginExternalTools.kt
+++ b/src/main/kotlin/io/qent/sona/tools/PluginExternalTools.kt
@@ -1,0 +1,11 @@
+package io.qent.sona.tools
+
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import io.qent.sona.core.ExternalTools
+
+class PluginExternalTools(private val project: Project) : ExternalTools {
+    override fun getFocusedFileText(): String? {
+        return FileEditorManager.getInstance(project).selectedTextEditor?.document?.text
+    }
+}


### PR DESCRIPTION
## Summary
- separate `Tools` into `InternalTools` and `ExternalTools`
- wire core `ChatFlow` and `StateProvider` through delegated tools implementation
- provide `PluginExternalTools` in the UI module

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6890d8ee056c8320b797dc3bdcdf3617