### PR TITLE
feat: add copyable code block

### DIFF
--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.intellij.openapi.util.IconLoader
 import com.mikepenz.markdown.compose.Markdown
+import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.rememberMarkdownState
 import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.UserMessage
@@ -156,6 +157,10 @@ fun MessageBubble(message: Any, isUser: Boolean, bottomContent: (@Composable () 
                             mdState,
                             colors = SonaTheme.markdownColors,
                             typography = SonaTheme.markdownTypography,
+                            components = markdownComponents(
+                                codeFence = { CopyableCodeBlock(it, true) },
+                                codeBlock = { CopyableCodeBlock(it, false) },
+                            ),
                         )
                     } else if (message is UserMessage) {
                         Text(

--- a/src/main/kotlin/io/qent/sona/ui/CopyableCodeBlock.kt
+++ b/src/main/kotlin/io/qent/sona/ui/CopyableCodeBlock.kt
@@ -1,0 +1,39 @@
+package io.qent.sona.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import com.mikepenz.markdown.compose.components.MarkdownComponentModel
+import com.mikepenz.markdown.compose.elements.MarkdownCodeBlock
+import com.mikepenz.markdown.compose.elements.MarkdownCodeFence
+import org.jetbrains.jewel.ui.component.IconButton
+
+/**
+ * Renders a markdown code block with a copy button overlay.
+ */
+@Composable
+fun CopyableCodeBlock(model: MarkdownComponentModel, fence: Boolean) {
+    val clipboard = LocalClipboardManager.current
+    Box {
+        if (fence) {
+            MarkdownCodeFence(model.content, model.node, style = model.typography.code)
+        } else {
+            MarkdownCodeBlock(model.content, model.node, style = model.typography.code)
+        }
+        IconButton(onClick = { clipboard.setText(AnnotatedString(model.content)) }, modifier = Modifier.align(Alignment.TopEnd)) {
+            Image(
+                painter = loadIcon("/icons/copy.svg"),
+                contentDescription = "Copy code",
+                colorFilter = ColorFilter.tint(SonaTheme.colors.AiText),
+                modifier = Modifier.size(12.dp)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow copying markdown code blocks with overlay button
- render markdown messages with custom code fence component

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6890e7df5604832082abe33ad5613254