### PR TITLE
Add file permission checks for file reading tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,10 @@ IDE theme changes.
 
 `ExternalTools` are implemented in the plugin module using the IntelliJ
 API while `InternalTools` live in the core module for plugin interactions like
-switching roles. The `Tools` interface extends both and is injected into
-`ChatFlow` via a core implementation that delegates to the two sets of tools.
+switching roles. `ToolsInfoDecorator` combines them and routes file responses through a
+permission manager that checks absolute paths against a whitelist (project root by default)
+and a blacklist of sensitive files before exposing file contents to the model.
+`ChatFlow` depends only on the `Tools` interface and receives the decorator from `StateProvider`.
 
 Whenever you extend the logic make sure the flow of state remains unidirectional
 and that the core module stays free from IntelliJ SDK imports.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ When the model requests to run a tool, the plugin asks for permission before
 executing it. You can allow the action once or choose **Always in this chat** to
 skip future confirmations for the same tool within the current conversation.
 
-The available tools let the model read the focused file and switch the active role between Architect and Code.
+The available tools let the model read the focused file, read any file by absolute path, and switch the active role between Architect and Code. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`.
 
 ## Copying and deleting messages
 

--- a/core/src/main/kotlin/io/qent/sona/core/ExternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ExternalTools.kt
@@ -1,5 +1,6 @@
 package io.qent.sona.core
 
 interface ExternalTools {
-    fun getFocusedFileText(): String?
+    fun getFocusedFileText(): FileInfo?
+    fun readFile(path: String): FileInfo?
 }

--- a/core/src/main/kotlin/io/qent/sona/core/FileInfo.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/FileInfo.kt
@@ -1,0 +1,6 @@
+package io.qent.sona.core
+
+data class FileInfo(
+    val path: String,
+    val content: String,
+)

--- a/core/src/main/kotlin/io/qent/sona/core/FilePermissionManager.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/FilePermissionManager.kt
@@ -1,0 +1,16 @@
+package io.qent.sona.core
+
+class FilePermissionManager(
+    private val repository: FilePermissionsRepository,
+) {
+    fun getFileContent(fileInfo: FileInfo): String {
+        val path = fileInfo.path
+        val whitelisted = repository.whitelist.any { Regex(it).matches(path) }
+        val blacklisted = repository.blacklist.any { Regex(it).matches(path) }
+        return if (whitelisted && !blacklisted) {
+            fileInfo.content
+        } else {
+            "Access to $path denied"
+        }
+    }
+}

--- a/core/src/main/kotlin/io/qent/sona/core/FilePermissionsRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/FilePermissionsRepository.kt
@@ -1,0 +1,6 @@
+package io.qent.sona.core
+
+interface FilePermissionsRepository {
+    val whitelist: List<String>
+    val blacklist: List<String>
+}

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -14,11 +14,13 @@ class StateProvider(
     private val rolesRepository: RolesRepository,
     modelFactory: (Preset) -> StreamingChatModel,
     externalTools: ExternalTools,
+    filePermissionManager: FilePermissionManager,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 ) {
 
     private val internalTools = DefaultInternalTools(scope, ::selectRole)
-    private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, internalTools, externalTools, scope)
+    private val tools: Tools = ToolsInfoDecorator(internalTools, externalTools, filePermissionManager)
+    private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, tools, scope)
 
     private val _state = MutableSharedFlow<State>(replay = 1)
 

--- a/core/src/main/kotlin/io/qent/sona/core/Tools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/Tools.kt
@@ -1,3 +1,6 @@
 package io.qent.sona.core
 
-interface Tools : InternalTools, ExternalTools
+interface Tools : InternalTools {
+    fun getFocusedFileText(): String
+    fun readFile(path: String): String
+}

--- a/core/src/main/kotlin/io/qent/sona/core/ToolsInfoDecorator.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ToolsInfoDecorator.kt
@@ -5,10 +5,20 @@ import dev.langchain4j.agent.tool.Tool
 class ToolsInfoDecorator(
     private val internalTools: InternalTools,
     private val externalTools: ExternalTools,
+    private val filePermissionManager: FilePermissionManager,
 ) : Tools {
 
     @Tool("Return source of file opened at current focused editor")
-    override fun getFocusedFileText() = externalTools.getFocusedFileText()
+    override fun getFocusedFileText(): String {
+        val fileInfo = externalTools.getFocusedFileText() ?: return ""
+        return filePermissionManager.getFileContent(fileInfo)
+    }
+
+    @Tool("Return content of file at given absolute path")
+    override fun readFile(path: String): String {
+        val fileInfo = externalTools.readFile(path) ?: return "File not found"
+        return filePermissionManager.getFileContent(fileInfo)
+    }
 
     @Tool("Switch agent role to Architect")
     override fun switchToArchitect() = internalTools.switchToArchitect()

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -12,6 +12,8 @@ import io.qent.sona.repositories.PluginChatRepository
 import io.qent.sona.repositories.PluginPresetsRepository
 import io.qent.sona.repositories.PluginRolesRepository
 import io.qent.sona.repositories.PluginSettingsRepository
+import io.qent.sona.repositories.PluginFilePermissionsRepository
+import io.qent.sona.core.FilePermissionManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -35,6 +37,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
     private var stateProvider: StateProvider
 
     private val externalTools = PluginExternalTools(project)
+    private val filePermissionManager = FilePermissionManager(PluginFilePermissionsRepository(project))
 
     var lastState: State = State.ChatState(
         messages = emptyList(),
@@ -92,6 +95,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
                 }
             },
             externalTools = externalTools,
+            filePermissionManager = filePermissionManager,
             scope = scope,
         )
 

--- a/src/main/kotlin/io/qent/sona/repositories/PluginFilePermissionsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginFilePermissionsRepository.kt
@@ -1,0 +1,16 @@
+package io.qent.sona.repositories
+
+import com.intellij.openapi.project.Project
+import io.qent.sona.core.FilePermissionsRepository
+
+class PluginFilePermissionsRepository(project: Project) : FilePermissionsRepository {
+    private val root = project.basePath ?: "/"
+    override val whitelist = listOf("$root/.*")
+    override val blacklist = listOf(
+        ".*/\\.env.*",
+        ".*/\\.git.*",
+        ".*/\\.idea/.*",
+        ".*/gradle.properties",
+        ".*/local\\.properties",
+    )
+}

--- a/src/main/kotlin/io/qent/sona/tools/PluginExternalTools.kt
+++ b/src/main/kotlin/io/qent/sona/tools/PluginExternalTools.kt
@@ -3,9 +3,24 @@ package io.qent.sona.tools
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import io.qent.sona.core.ExternalTools
+import io.qent.sona.core.FileInfo
+import java.nio.file.Files
+import java.nio.file.Paths
 
 class PluginExternalTools(private val project: Project) : ExternalTools {
-    override fun getFocusedFileText(): String? {
-        return FileEditorManager.getInstance(project).selectedTextEditor?.document?.text
+    override fun getFocusedFileText(): FileInfo? {
+        val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return null
+        val file = editor.virtualFile ?: return null
+        return FileInfo(file.path, editor.document.text)
+    }
+
+    override fun readFile(path: String): FileInfo? {
+        return try {
+            val p = Paths.get(path)
+            val content = Files.readString(p)
+            FileInfo(p.toAbsolutePath().toString(), content)
+        } catch (_: Exception) {
+            null
+        }
     }
 }


### PR DESCRIPTION
## Summary
- decouple `ChatFlow` from concrete tool types by injecting a unified `Tools` interface
- create `ToolsInfoDecorator` in `StateProvider` and pass it to `ChatFlow`
- document the new tools wiring in `AGENTS.md`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6890ea91188c83208b0771084fddeeff