### PR TITLE
feat: add environment system message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@
 - Plugin settings contain only the "Ignore HTTPS errors" flag which, when enabled, trusts all HTTPS certificates.
 - Each chat tracks tools approved by the user so that previously allowed tools run without asking again.
 - A tool is available to switch the active role between Architect and Code.
+- The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
+  environment (OS, IDE, Java, Python, Node.js, project languages, file extensions and build systems) and is prepended to every LLM request.
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ prompt text. Roles can be added, selected and removed, but the default Architect
 and Code roles cannot be deleted. The active role can also be changed directly
 from the chat via the selector under the message input. The text of the active
 role is sent as a system message with every request but is not stored in the
-chat history.
+chat history. Every request is also prefixed with a system message summarizing
+the current environment (OS, IDE, Java, Python, Node.js versions, project
+languages, file extension statistics and build systems).
 
 Models can also switch roles themselves using tools to toggle between Architect and Code.
 

--- a/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
@@ -35,6 +35,7 @@ class ChatFlow(
     internalTools: InternalTools,
     externalTools: ExternalTools,
     scope: CoroutineScope,
+    private val systemMessages: List<SystemMessage> = emptyList(),
 ) : Flow<Chat> {
 
     private val scope = scope + Dispatchers.IO
@@ -87,10 +88,10 @@ class ChatFlow(
             val model = modelFactory(preset)
 
             val roleText = rolesRepository.load().let { it.roles[it.active].text }
-            val systemMessage = SystemMessage.from(roleText)
+            val roleMessage = SystemMessage.from(roleText)
 
             var chatRequestBuilder =
-                ChatRequestBuilder((listOf(systemMessage) + baseMessages.map { it.message }).toMutableList())
+                ChatRequestBuilder((systemMessages + roleMessage + baseMessages.map { it.message }).toMutableList())
             chatRequestBuilder.parameters(configurer = {
                 toolSpecifications = ToolSpecifications.toolSpecificationsFrom(tools)
             })
@@ -154,7 +155,7 @@ class ChatFlow(
                 ))
 
                 chatRequestBuilder =
-                    ChatRequestBuilder((listOf(systemMessage) + messagesWithToolsResponse.map { it.message }).toMutableList())
+                    ChatRequestBuilder((systemMessages + roleMessage + messagesWithToolsResponse.map { it.message }).toMutableList())
                 chatRequestBuilder.parameters(configurer = {
                     toolSpecifications = ToolSpecifications.toolSpecificationsFrom(tools)
                 })

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -1,5 +1,6 @@
 package io.qent.sona.core
 
+import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.output.TokenUsage
 import kotlinx.coroutines.CoroutineScope
@@ -14,11 +15,12 @@ class StateProvider(
     private val rolesRepository: RolesRepository,
     modelFactory: (Preset) -> StreamingChatModel,
     externalTools: ExternalTools,
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+    private val systemMessages: List<SystemMessage> = emptyList(),
 ) {
 
     private val internalTools = DefaultInternalTools(scope, ::selectRole)
-    private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, internalTools, externalTools, scope)
+    private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, internalTools, externalTools, scope, systemMessages)
 
     private val _state = MutableSharedFlow<State>(replay = 1)
 

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -3,9 +3,11 @@ package io.qent.sona
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.application.ApplicationInfo
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
 import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
+import dev.langchain4j.data.message.SystemMessage
 import io.qent.sona.core.*
 import io.qent.sona.tools.PluginExternalTools
 import io.qent.sona.repositories.PluginChatRepository
@@ -19,6 +21,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import java.io.File
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.net.ssl.*
@@ -93,6 +96,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
             },
             externalTools = externalTools,
             scope = scope,
+            systemMessages = createSystemMessages(),
         )
 
         stateProvider.state.onEach {
@@ -112,6 +116,131 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
                 HttpsURLConnection.setDefaultHostnameVerifier { _: String?, _: SSLSession? -> true }
             }
         }
+    }
+
+    private fun createSystemMessages(): List<SystemMessage> {
+        return listOf(SystemMessage.from(environmentInfo()))
+    }
+
+    private fun environmentInfo(): String {
+        val os = "${System.getProperty("os.name")} ${System.getProperty("os.version")}".trim()
+        val ide = ApplicationInfo.getInstance().fullApplicationName
+        val java = System.getProperty("java.version")
+        val python = runCommand("python", "--version")
+        val node = runCommand("node", "--version")
+        val base = project.basePath?.let { File(it) }
+        val extCounts = collectExtensionStats(base)
+        val language = detectLanguages(extCounts)
+        val extensions = formatExtensionStats(extCounts)
+        val builds = detectBuildSystems(base)
+        return listOf(
+            "OS: $os",
+            "IDE: $ide",
+            "Java: $java",
+            "Python: $python",
+            "Node: $node",
+            "Languages: $language",
+            "Extensions: $extensions",
+            "Build systems: $builds",
+        ).joinToString("\n")
+    }
+
+    private fun runCommand(vararg cmd: String): String {
+        return runCatching {
+            val proc = ProcessBuilder(*cmd).redirectErrorStream(true).start()
+            proc.inputStream.bufferedReader().use { it.readText() }.trim()
+        }.getOrElse { "Unknown" }
+    }
+
+    private fun detectBuildSystems(base: File?): String {
+        if (base == null) return "Unknown"
+        val systems = mutableSetOf<String>()
+        base.walkTopDown().maxDepth(2).forEach { f ->
+            if (f.isFile) {
+                when (f.name.lowercase()) {
+                    "build.gradle.kts", "build.gradle" -> systems.add("Gradle")
+                    "pom.xml" -> systems.add("Maven")
+                    "build.xml" -> systems.add("Ant")
+                    "build.sbt" -> systems.add("sbt")
+                    "package.json" -> systems.add("npm")
+                    "yarn.lock" -> systems.add("Yarn")
+                    "pnpm-lock.yaml", "pnpm-lock.yml" -> systems.add("pnpm")
+                    "requirements.txt" -> systems.add("pip")
+                    "pyproject.toml" -> systems.add("Poetry")
+                    "cmakelists.txt" -> systems.add("CMake")
+                    "makefile" -> systems.add("Make")
+                    "cargo.toml" -> systems.add("Cargo")
+                }
+            }
+        }
+        return if (systems.isEmpty()) "Unknown" else systems.sorted().joinToString(", ")
+    }
+
+    private val extensionLanguages = mapOf(
+        "kt" to "Kotlin",
+        "kts" to "Kotlin",
+        "java" to "Java",
+        "groovy" to "Groovy",
+        "scala" to "Scala",
+        "clj" to "Clojure",
+        "py" to "Python",
+        "rb" to "Ruby",
+        "php" to "PHP",
+        "go" to "Go",
+        "rs" to "Rust",
+        "swift" to "Swift",
+        "m" to "Objective-C",
+        "mm" to "Objective-C++",
+        "cs" to "C#",
+        "fs" to "F#",
+        "c" to "C",
+        "cc" to "C++",
+        "cpp" to "C++",
+        "cxx" to "C++",
+        "h" to "C/C++",
+        "hpp" to "C++",
+        "hxx" to "C++",
+        "js" to "JavaScript",
+        "jsx" to "JavaScript",
+        "ts" to "TypeScript",
+        "tsx" to "TypeScript",
+        "html" to "HTML",
+        "htm" to "HTML",
+        "css" to "CSS",
+        "scss" to "SCSS",
+        "less" to "Less",
+        "xml" to "XML",
+        "json" to "JSON",
+        "yml" to "YAML",
+        "yaml" to "YAML",
+        "md" to "Markdown",
+        "dart" to "Dart",
+    )
+
+    private fun collectExtensionStats(base: File?): Map<String, Int> {
+        if (base == null) return emptyMap()
+        val counts = mutableMapOf<String, Int>()
+        base.walkTopDown().maxDepth(4).forEach { f ->
+            if (f.isFile) {
+                val ext = f.extension.lowercase()
+                if (extensionLanguages.containsKey(ext)) {
+                    counts[ext] = counts.getOrDefault(ext, 0) + 1
+                }
+            }
+        }
+        return counts
+    }
+
+    private fun detectLanguages(counts: Map<String, Int>): String {
+        if (counts.isEmpty()) return "Unknown"
+        val languages = counts.keys.mapNotNull { extensionLanguages[it] }.toSet().sorted()
+        return languages.joinToString(", ")
+    }
+
+    private fun formatExtensionStats(counts: Map<String, Int>): String {
+        if (counts.isEmpty()) return "Unknown"
+        return counts.entries.sortedByDescending { it.value }
+            .joinToString(", ") { "${it.key}(${it.value})" }
     }
 
     override suspend fun collect(collector: FlowCollector<State>) {


### PR DESCRIPTION
## Summary
- allow UI to supply extra system messages to the core
- prepend environment details (OS, IDE, runtimes, project info) to every LLM request
- expand environment info with build system detection and file extension statistics

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6890fb1a04248320907d227cba62550c