### PR TITLE
feat: add mcp server configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,9 @@ permission manager that checks absolute paths against a whitelist (project root 
 and a blacklist of sensitive files before exposing file contents to the model.
 File permissions can also be adjusted by adding a `sona.json` file at the project root with
 `permissions.files.whitelist` and `blacklist` arrays of regex patterns.
+`sona.json` may additionally define an `mcpServers` array with Model Context Protocol server
+configurations including name, command, arguments, environment variables, transport, URL,
+working directory and request headers.
 `ChatFlow` depends only on the `Tools` interface and receives the decorator from `StateProvider`.
 
 Whenever you extend the logic make sure the flow of state remains unidirectional

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The available tools let the model read the focused file, read any file by absolu
 }
 ```
 
+The same configuration file can also include an `mcpServers` array specifying Model Context Protocol
+servers. Each entry supports `name`, `command`, `args`, `env`, `transport`, `url`, `cwd` and `headers` fields.
+
 ## Copying and deleting messages
 
 When hovering a message, copy and delete icons appear beneath its bottom‑right corner.

--- a/core/src/main/kotlin/io/qent/sona/core/McpServersRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/McpServersRepository.kt
@@ -1,0 +1,16 @@
+package io.qent.sona.core
+
+data class McpServerConfig(
+    val name: String,
+    val command: String? = null,
+    val args: List<String>? = null,
+    val env: Map<String, String>? = null,
+    val transport: String? = null,
+    val url: String? = null,
+    val cwd: String? = null,
+    val headers: Map<String, String>? = null,
+)
+
+interface McpServersRepository {
+    suspend fun list(): List<McpServerConfig>
+}

--- a/src/main/kotlin/io/qent/sona/config/SonaConfig.kt
+++ b/src/main/kotlin/io/qent/sona/config/SonaConfig.kt
@@ -5,6 +5,7 @@ import java.io.File
 
 class SonaConfig {
     var permissions: Permissions? = null
+    var mcpServers: List<McpServer>? = null
 
     class Permissions {
         var files: Files? = null
@@ -13,6 +14,17 @@ class SonaConfig {
             var whitelist: List<String>? = null
             var blacklist: List<String>? = null
         }
+    }
+
+    class McpServer {
+        var name: String? = null
+        var command: String? = null
+        var args: List<String>? = null
+        var env: Map<String, String>? = null
+        var transport: String? = null
+        var url: String? = null
+        var cwd: String? = null
+        var headers: Map<String, String>? = null
     }
 
     companion object {

--- a/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
@@ -1,0 +1,28 @@
+package io.qent.sona.repositories
+
+import com.intellij.openapi.project.Project
+import io.qent.sona.config.SonaConfig
+import io.qent.sona.core.McpServerConfig
+import io.qent.sona.core.McpServersRepository
+
+class PluginMcpServersRepository(project: Project) : McpServersRepository {
+    private val root = project.basePath ?: "/"
+    private val config = SonaConfig.load(root)
+
+    override suspend fun list(): List<McpServerConfig> {
+        val servers = config?.mcpServers ?: return emptyList()
+        return servers.mapNotNull { server ->
+            val name = server.name ?: return@mapNotNull null
+            McpServerConfig(
+                name = name,
+                command = server.command,
+                args = server.args,
+                env = server.env,
+                transport = server.transport,
+                url = server.url,
+                cwd = server.cwd,
+                headers = server.headers,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support `mcpServers` in `sona.json` with command, args, env and network details
- add `McpServersRepository` interface and IntelliJ implementation
- document MCP server configuration in AGENTS and README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6891075e7904832099af154bc3790a1c