### PR TITLE
feat: add environment system message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@
 - Plugin settings contain only the "Ignore HTTPS errors" flag which, when enabled, trusts all HTTPS certificates.
 - Each chat tracks tools approved by the user so that previously allowed tools run without asking again.
 - A tool is available to switch the active role between Architect and Code.
+- The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
+  environment (OS, IDE, Java, Python, Node.js, file extension statistics, build systems) and is prepended to every LLM request.
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ prompt text. Roles can be added, selected and removed, but the default Architect
 and Code roles cannot be deleted. The active role can also be changed directly
 from the chat via the selector under the message input. The text of the active
 role is sent as a system message with every request but is not stored in the
-chat history.
+chat history. Every request is also prefixed with a system message summarizing
+the current environment (OS, IDE, Java, Python, Node.js versions, file extension
+statistics and build systems).
 
 Models can also switch roles themselves using tools to toggle between Architect and Code.
 

--- a/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
@@ -35,6 +35,7 @@ class ChatFlow(
     private val modelFactory: (Preset) -> StreamingChatModel,
     private val tools: Tools,
     scope: CoroutineScope,
+    private val systemMessages: List<SystemMessage> = emptyList(),
 ) : Flow<Chat> {
 
     private val scope = scope + Dispatchers.IO
@@ -86,10 +87,10 @@ class ChatFlow(
             val model = modelFactory(preset)
 
             val roleText = rolesRepository.load().let { it.roles[it.active].text }
-            val systemMessage = SystemMessage.from(roleText)
+            val roleMessage = SystemMessage.from(roleText)
 
             var chatRequestBuilder =
-                ChatRequestBuilder((listOf(systemMessage) + baseMessages.map { it.message }).toMutableList())
+                ChatRequestBuilder((systemMessages + roleMessage + baseMessages.map { it.message }).toMutableList())
             chatRequestBuilder.parameters(configurer = {
                 toolSpecifications = ToolSpecifications.toolSpecificationsFrom(tools)
             })
@@ -163,7 +164,7 @@ class ChatFlow(
                 ))
 
                 chatRequestBuilder =
-                    ChatRequestBuilder((listOf(systemMessage) + messagesWithToolsResponse.map { it.message }).toMutableList())
+                    ChatRequestBuilder((systemMessages + roleMessage + messagesWithToolsResponse.map { it.message }).toMutableList())
                 chatRequestBuilder.parameters(configurer = {
                     toolSpecifications = ToolSpecifications.toolSpecificationsFrom(tools)
                 })

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -1,5 +1,6 @@
 package io.qent.sona.core
 
+import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.output.TokenUsage
 import kotlinx.coroutines.CoroutineScope
@@ -15,13 +16,14 @@ class StateProvider(
     modelFactory: (Preset) -> StreamingChatModel,
     externalTools: ExternalTools,
     filePermissionRepository: FilePermissionsRepository,
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+    private val systemMessages: List<SystemMessage> = emptyList(),
 ) {
 
     private val filePermissionManager = FilePermissionManager(filePermissionRepository)
     private val internalTools = DefaultInternalTools(scope, ::selectRole)
     private val tools: Tools = ToolsInfoDecorator(internalTools, externalTools, filePermissionManager)
-    private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, tools, scope)
+    private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, tools, scope, systemMessages)
 
     private val _state = MutableSharedFlow<State>(replay = 1)
 


### PR DESCRIPTION
## Summary
- allow UI to supply extra system messages to the core
- prepend environment details (OS, IDE, runtimes, file extension statistics, build systems) to every LLM request

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6890fb1a04248320907d227cba62550c