### PR TITLE
Refactor token usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ current conversation state:
 ```
 data class Chat(
     val chatId: String,
-    val tokenUsage: TokenUsage,
+    val tokenUsage: TokenUsageInfo,
     val messages: List<ChatRepositoryMessage> = emptyList(),
     val requestInProgress: Boolean = false,
     val toolRequest: String? = null
@@ -120,6 +120,13 @@ data class Chat(
 `StateProvider` consumes `ChatFlow` and maps it to a higher level
 `State` model used by the UI. Both `ChatFlow` and `StateProvider`
 operate purely on Kotlin flows without any IntelliJ types.
+
+`tokenUsage` represents the cumulative input, output and cached tokens
+spent for all AI responses in the chat. Each AI message also
+stores its own token usage including cached tokens while user messages
+always record zeros. Providers that do not expose cache statistics
+simply report zero cached tokens. Removing messages does not affect the
+total usage stored for the chat.
 
 Repositories for settings and chat history are declared as interfaces in
 `core` so that the UI module can provide IDE specific implementations.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,5 +17,6 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.langchain4j.core)
     implementation(libs.langchain4j.kotlin)
+    implementation(libs.langchain4j.anthropic)
     implementation(libs.langchain4j.mcp)
 }

--- a/core/src/main/kotlin/io/qent/sona/core/ChatRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatRepository.kt
@@ -17,12 +17,14 @@ interface ChatRepository {
         chatId: String,
         message: ChatMessage,
         model: String,
-        inputTokens: Int = 0,
-        outputTokens: Int = 0,
+        tokenUsage: TokenUsageInfo = TokenUsageInfo(),
     )
 
     /** Load all messages for a chat. */
     suspend fun loadMessages(chatId: String): List<ChatRepositoryMessage>
+
+    /** Load total token usage for a chat. */
+    suspend fun loadTokenUsage(chatId: String): TokenUsageInfo
 
     /** Check if a [toolName] is allowed to execute in the chat. */
     suspend fun isToolAllowed(chatId: String, toolName: String): Boolean
@@ -44,8 +46,7 @@ data class ChatRepositoryMessage(
     val chatId: String,
     val message: ChatMessage,
     val model: String,
-    val inputTokens: Int = 0,
-    val outputTokens: Int = 0,
+    val tokenUsage: TokenUsageInfo = TokenUsageInfo(),
 )
 
 data class ChatSummary(

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -10,8 +10,8 @@ sealed class State {
 
     data class ChatState(
         val messages: List<ChatMessage>,
-        val outputTokens: Int,
-        val inputTokens: Int,
+        val totalTokenUsage: TokenUsageInfo,
+        val lastTokenUsage: TokenUsageInfo,
         val isSending: Boolean,
         val roles: List<String>,
         val activeRole: Int,

--- a/core/src/main/kotlin/io/qent/sona/core/TokenUsageInfo.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/TokenUsageInfo.kt
@@ -1,0 +1,45 @@
+package io.qent.sona.core
+
+import dev.langchain4j.model.anthropic.AnthropicTokenUsage
+import dev.langchain4j.model.output.TokenUsage
+
+/**
+ * Container for token usage statistics including cached tokens.
+ *
+ * [outputTokens] and [inputTokens] represent tokens generated and
+ * consumed for a response respectively. [cachedOutputTokens] and
+ * [cachedInputTokens] track tokens served from or stored in provider
+ * caches. Providers that do not expose cache statistics should set
+ * cached counts to zero.
+ */
+data class TokenUsageInfo(
+    val outputTokens: Int = 0,
+    val inputTokens: Int = 0,
+    val cachedOutputTokens: Int = 0,
+    val cachedInputTokens: Int = 0,
+) {
+    operator fun plus(other: TokenUsageInfo) = TokenUsageInfo(
+        outputTokens + other.outputTokens,
+        inputTokens + other.inputTokens,
+        cachedOutputTokens + other.cachedOutputTokens,
+        cachedInputTokens + other.cachedInputTokens,
+    )
+}
+
+/** Convert LangChain4j [TokenUsage] to [TokenUsageInfo]. */
+fun TokenUsage.toInfo(): TokenUsageInfo {
+    val cachedInput =
+        if (this is AnthropicTokenUsage) {
+            (cacheCreationInputTokens() ?: 0) + (cacheReadInputTokens() ?: 0)
+        } else {
+            0
+        }
+
+    return TokenUsageInfo(
+        outputTokens = outputTokenCount(),
+        inputTokens = inputTokenCount(),
+        cachedOutputTokens = 0,
+        cachedInputTokens = cachedInput,
+    )
+}
+

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -44,8 +44,8 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
 
     var lastState: State = State.ChatState(
         messages = emptyList(),
-        outputTokens = 0,
-        inputTokens = 0,
+        totalTokenUsage = TokenUsageInfo(),
+        lastTokenUsage = TokenUsageInfo(),
         isSending = false,
         roles = emptyList(),
         activeRole = 0,

--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -73,8 +73,15 @@ fun ChatPanel(state: ChatState) {
 
 @Composable
 private fun Header(state: ChatState) {
-    Row(Modifier.fillMaxWidth().padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
-        Text("Out: ${state.outputTokens}  In: ${state.inputTokens}")
+    Column(Modifier.fillMaxWidth().padding(8.dp)) {
+        Text(
+            "Out: ${state.totalTokenUsage.outputTokens}  In: ${state.totalTokenUsage.inputTokens}  " +
+                "CachedOut: ${state.totalTokenUsage.cachedOutputTokens}  CachedIn: ${state.totalTokenUsage.cachedInputTokens}"
+        )
+        Text(
+            "Last Out: ${state.lastTokenUsage.outputTokens}  In: ${state.lastTokenUsage.inputTokens}  " +
+                "CachedOut: ${state.lastTokenUsage.cachedOutputTokens}  CachedIn: ${state.lastTokenUsage.cachedInputTokens}"
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Introduce `TokenUsageInfo` to capture input, output and cached token counts
- Persist cached token usage in repositories and aggregate totals through chat flow
- Display total and last-response token usage (including cached counts) in the chat header and update docs

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68917fec38388320b37ea8179577f354