### PR TITLE
Add auto-approve tools toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@
   to work and they are managed from the Presets screen.
 - Plugin settings contain only the "Ignore HTTPS errors" flag which, when enabled, trusts all HTTPS certificates.
 - Each chat tracks tools approved by the user so that previously allowed tools run without asking again.
+- A 🤘 button next to the send action can temporarily auto-approve all tool
+  requests in the current chat. The setting resets when switching chats and is
+  not persisted.
 - A tool is available to switch the active role between Architect and Code.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
   environment (OS, IDE, Java, Python, Node.js, file extension statistics, build systems) and is prepended to every LLM request.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ When the model requests to run a tool, the plugin asks for permission before
 executing it. You can allow the action once or choose **Always in this chat** to
 skip future confirmations for the same tool within the current conversation.
 
+A 🤘 button next to the send action toggles automatic approval of all tool
+requests in the current chat. When enabled, tools run without prompting until
+you switch to a different chat.
+
 The available tools let the model read the focused file, read any file by absolute path, and switch the active role between Architect and Code. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`. Custom lists can be supplied by creating a `sona.json` file in the project root:
 
 ```

--- a/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatFlow.kt
@@ -27,6 +27,7 @@ data class Chat(
     val requestInProgress: Boolean = false,
     val isStreaming: Boolean = false,
     val toolRequest: String? = null,
+    val autoApproveTools: Boolean = false,
 )
 
 class ChatFlow(
@@ -106,7 +107,7 @@ class ChatFlow(
                 val messagesWithToolsResponse = currentState.messages.toMutableList()
                 for (toolRequest in responseMessage.toolExecutionRequests()) {
                     val toolName = toolRequest.name()
-                    val decision = if (chatRepository.isToolAllowed(chatId, toolName)) {
+                    val decision = if (currentState.autoApproveTools || chatRepository.isToolAllowed(chatId, toolName)) {
                         ToolDecision(true, false)
                     } else {
                         requestToolPermission(toolName)
@@ -242,6 +243,10 @@ class ChatFlow(
         toolContinuation?.resume(ToolDecision(allow, always))
         toolContinuation = null
         emit(currentState.copy(toolRequest = null))
+    }
+
+    fun toggleAutoApproveTools() {
+        emit(currentState.copy(autoApproveTools = !currentState.autoApproveTools))
     }
 
     private suspend fun streamChat(

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -22,6 +22,8 @@ sealed class State {
         val onStop: () -> Unit,
         val onDeleteFrom: (Int) -> Unit,
         val toolRequest: Boolean,
+        val autoApproveTools: Boolean,
+        val onToggleAutoApprove: () -> Unit,
         val onAllowTool: () -> Unit,
         val onAlwaysAllowTool: () -> Unit,
         val onDenyTool: () -> Unit,

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -91,6 +91,8 @@ class StateProvider(
             onStop = { scope.launch { stop() } },
             onDeleteFrom = { idx -> scope.launch { deleteFrom(idx) } },
             toolRequest = chat.toolRequest != null,
+            autoApproveTools = chat.autoApproveTools,
+            onToggleAutoApprove = { scope.launch { chatFlow.toggleAutoApproveTools() } },
             onAllowTool = { scope.launch { chatFlow.resolveToolPermission(true, false) } },
             onAlwaysAllowTool = { scope.launch { chatFlow.resolveToolPermission(true, true) } },
             onDenyTool = { scope.launch { chatFlow.resolveToolPermission(false, false) } },

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -56,6 +56,8 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
         onStop = {},
         onDeleteFrom = {},
         toolRequest = false,
+        autoApproveTools = false,
+        onToggleAutoApprove = {},
         onAllowTool = {},
         onAlwaysAllowTool = {},
         onDenyTool = {},

--- a/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ChatPanel.kt
@@ -326,71 +326,83 @@ private fun Input(state: ChatState) {
             modifier = Modifier.align(Alignment.BottomStart).padding(6.dp).offset(x = 115.dp).alpha(0.6f)
         )
 
-        if (state.isSending) {
-            val transition = rememberInfiniteTransition(label = "stopPulse")
-            val scale by transition.animateFloat(
-                initialValue = 1f,
-                targetValue = 1f,
-                animationSpec = infiniteRepeatable(
-                    animation = keyframes {
-                        durationMillis = 1500
-                        0.95f at 200
-                        1.1f at 400
-                        0.8f at 700
-                        1.10f at 1000
-                        0.85f at 1300
-                        1.15f at 1600
-                        0.9f at 2000
-                    }
-                ),
-                label = "scale"
-            )
 
-            Box(
-                modifier = Modifier
-                    .padding(4.dp)
-                    .size(30.dp)
-                    .align(Alignment.BottomEnd),
-                contentAlignment = Alignment.Center
-            ) {
-                Box(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .graphicsLayer {
-                            scaleX = scale
-                            scaleY = scale
-                        }
-                        .clip(CircleShape)
-                        .background(Color.White.copy(alpha = 0.2f))
-                )
-
-                ActionButton(
-                    onClick = { state.onStop() },
-                    modifier = Modifier
-                        .matchParentSize()
-                        .clip(CircleShape)
-                ) {
-                    Text("■")
-                }
-            }
-        } else {
+        Row(
+            modifier = Modifier.align(Alignment.BottomEnd).padding(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             ActionButton(
-                onClick = {
-                    if (text.value.isNotBlank()) {
-                        state.onSendMessage(text.value)
-                        text.value = ""
-                    }
-                },
-                enabled = text.value.isNotBlank(),
+                onClick = { state.onToggleAutoApprove() },
                 modifier = Modifier
-                    .padding(4.dp)
                     .height(30.dp)
                     .width(30.dp)
                     .clip(CircleShape)
-                    .alpha(alpha = if (text.value.isBlank()) 0.4f else 1f)
-                    .align(Alignment.BottomEnd)
+                    .alpha(if (state.autoApproveTools) 0.6f else 0.3f)
             ) {
-                Text("➤")
+                Text("🤘")
+            }
+            Spacer(Modifier.width(4.dp))
+            if (state.isSending) {
+                val transition = rememberInfiniteTransition(label = "stopPulse")
+                val scale by transition.animateFloat(
+                    initialValue = 1f,
+                    targetValue = 1f,
+                    animationSpec = infiniteRepeatable(
+                        animation = keyframes {
+                            durationMillis = 1500
+                            0.95f at 200
+                            1.1f at 400
+                            0.8f at 700
+                            1.10f at 1000
+                            0.85f at 1300
+                            1.15f at 1600
+                            0.9f at 2000
+                        }
+                    ),
+                    label = "scale",
+                )
+
+                Box(
+                    modifier = Modifier.size(30.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .graphicsLayer {
+                                scaleX = scale
+                                scaleY = scale
+                            }
+                            .clip(CircleShape)
+                            .background(Color.White.copy(alpha = 0.2f))
+                    )
+
+                    ActionButton(
+                        onClick = { state.onStop() },
+                        modifier = Modifier
+                            .matchParentSize()
+                            .clip(CircleShape),
+                    ) {
+                        Text("■")
+                    }
+                }
+            } else {
+                ActionButton(
+                    onClick = {
+                        if (text.value.isNotBlank()) {
+                            state.onSendMessage(text.value)
+                            text.value = ""
+                        }
+                    },
+                    enabled = text.value.isNotBlank(),
+                    modifier = Modifier
+                        .height(30.dp)
+                        .width(30.dp)
+                        .clip(CircleShape)
+                        .alpha(alpha = if (text.value.isBlank()) 0.4f else 1f),
+                ) {
+                    Text("➤")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add per-chat auto-approve toggle for tools
- auto-approve state resets when switching chats
- document auto-approve toggle in README and AGENTS

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6891b741e8288320a4ef9aad2e96cee8