### PR TITLE
Use custom HTTP client when ignoring HTTPS errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,11 @@ dependencies {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
     }
 
+    implementation(libs.langchain4j.http.client.jdk) {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+    }
+
     implementation(libs.langchain4j.mcp) {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,11 +8,12 @@ kover = "0.9.1"
 qodana = "2024.3.4"
 langchain4j_core = "1.0.0"
 langchain4j_kotlin = "1.0.0-beta5"
-langchain4j_anthropic = "1.0.0-beta5"
+langchain4j_anthropic = "1.2.0"
 langchain4j_openai = "1.2.0"
 langchain4j_google_ai_gemini = "1.2.0"
 gson = "2.10.1"
 langchain4j_mcp = "1.0.0-beta5"
+langchain4j_http_client_jdk = "1.2.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -25,6 +26,7 @@ langchain4j-openai = { group = "dev.langchain4j", name = "langchain4j-open-ai", 
 langchain4j-google-ai-gemini = { group = "dev.langchain4j", name = "langchain4j-google-ai-gemini", version.ref = "langchain4j_google_ai_gemini" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 langchain4j-mcp = { group = "dev.langchain4j", name = "langchain4j-mcp", version.ref = "langchain4j_mcp" }
+langchain4j-http-client-jdk = { group = "dev.langchain4j", name = "langchain4j-http-client-jdk", version.ref = "langchain4j_http_client_jdk" }
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -8,6 +8,8 @@ import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
 import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.data.message.SystemMessage
+import dev.langchain4j.http.client.jdk.JdkHttpClient
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
 import io.qent.sona.core.*
 import io.qent.sona.tools.PluginExternalTools
 import io.qent.sona.repositories.PluginChatRepository
@@ -23,10 +25,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import java.io.File
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import java.net.http.HttpClient
 import javax.net.ssl.*
 
 
@@ -72,29 +74,49 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
             rolesRepository,
             modelFactory = { preset ->
                 when (preset.provider) {
-                    LlmProvider.Anthropic -> AnthropicStreamingChatModel.builder()
-                        .apiKey(preset.apiKey)
-                        .baseUrl(preset.apiEndpoint)
-                        .modelName(preset.model)
-                        .build()
+                    LlmProvider.Anthropic -> {
+                        val builder = AnthropicStreamingChatModel.builder()
+                            .apiKey(preset.apiKey)
+                            .baseUrl(preset.apiEndpoint)
+                            .modelName(preset.model)
+                        if (settingsRepository.state.ignoreHttpsErrors) {
+                            builder.httpClientBuilder(ignoreHttpsClientBuilder())
+                        }
+                        builder.build()
+                    }
 
-                    LlmProvider.OpenAI -> OpenAiStreamingChatModel.builder()
-                        .apiKey(preset.apiKey)
-                        .baseUrl(preset.apiEndpoint)
-                        .modelName(preset.model)
-                        .build()
+                    LlmProvider.OpenAI -> {
+                        val builder = OpenAiStreamingChatModel.builder()
+                            .apiKey(preset.apiKey)
+                            .baseUrl(preset.apiEndpoint)
+                            .modelName(preset.model)
+                        if (settingsRepository.state.ignoreHttpsErrors) {
+                            builder.httpClientBuilder(ignoreHttpsClientBuilder())
+                        }
+                        builder.build()
+                    }
 
-                    LlmProvider.Deepseek -> OpenAiStreamingChatModel.builder()
-                        .apiKey(preset.apiKey)
-                        .baseUrl(preset.apiEndpoint)
-                        .modelName(preset.model)
-                        .build()
+                    LlmProvider.Deepseek -> {
+                        val builder = OpenAiStreamingChatModel.builder()
+                            .apiKey(preset.apiKey)
+                            .baseUrl(preset.apiEndpoint)
+                            .modelName(preset.model)
+                        if (settingsRepository.state.ignoreHttpsErrors) {
+                            builder.httpClientBuilder(ignoreHttpsClientBuilder())
+                        }
+                        builder.build()
+                    }
 
-                    LlmProvider.Gemini -> GoogleAiGeminiStreamingChatModel.builder()
-                        .apiKey(preset.apiKey)
-                        .baseUrl(preset.apiEndpoint)
-                        .modelName(preset.model)
-                        .build()
+                    LlmProvider.Gemini -> {
+                        val builder = GoogleAiGeminiStreamingChatModel.builder()
+                            .apiKey(preset.apiKey)
+                            .baseUrl(preset.apiEndpoint)
+                            .modelName(preset.model)
+                        if (settingsRepository.state.ignoreHttpsErrors) {
+                            builder.httpClientBuilder(ignoreHttpsClientBuilder())
+                        }
+                        builder.build()
+                    }
                 }
             },
             externalTools = externalTools,
@@ -107,20 +129,19 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
         stateProvider.state.onEach {
             lastState = it
         }.launchIn(scope)
+    }
 
-        scope.launch {
-            if (settingsRepository.load().ignoreHttpsErrors) {
-                val trustAll: Array<TrustManager> = arrayOf(object : X509TrustManager {
-                    override fun checkClientTrusted(c: Array<X509Certificate?>?, a: String?) = Unit
-                    override fun checkServerTrusted(c: Array<X509Certificate?>?, a: String?) = Unit
-                    override fun getAcceptedIssuers(): Array<X509Certificate?>? = arrayOfNulls(0)
-                })
-                val sc = SSLContext.getInstance("SSL")
-                sc.init(null, trustAll, SecureRandom())
-                HttpsURLConnection.setDefaultSSLSocketFactory(sc.socketFactory)
-                HttpsURLConnection.setDefaultHostnameVerifier { _: String?, _: SSLSession? -> true }
-            }
+    private fun ignoreHttpsClientBuilder(): JdkHttpClientBuilder {
+        val trustAll: Array<TrustManager> = arrayOf(object : X509TrustManager {
+            override fun checkClientTrusted(certs: Array<X509Certificate?>?, authType: String?) = Unit
+            override fun checkServerTrusted(certs: Array<X509Certificate?>?, authType: String?) = Unit
+            override fun getAcceptedIssuers(): Array<X509Certificate?>? = arrayOfNulls(0)
+        })
+        val sslContext = SSLContext.getInstance("SSL").apply {
+            init(null, trustAll, SecureRandom())
         }
+        val httpClientBuilder = HttpClient.newBuilder().sslContext(sslContext)
+        return JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
     }
 
     private fun createSystemMessages(): List<SystemMessage> {


### PR DESCRIPTION
## Summary
- use langchain4j's customizable HTTP client instead of global SSL overrides
- add langchain4j-http-client-jdk dependency and update Anthropics to 1.2.0

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6891b89e9cf883209e87418992baf5c5