### PR TITLE
feat: show MCP server status

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ servers. Each entry supports `name`, `command`, `args`, `env`, `transport`, `url
 Currently `transport` may be `stdio` or `http`. Every server runs in its own coroutine so a failure does
 not affect the plugin. Tools provided by MCP servers require the same user confirmation as local tools.
 
+The tool window includes a **Servers** action listing all configured MCP servers together with their current
+connection status.
+
 ```json
 {
   "mcpServers": [

--- a/core/src/main/kotlin/io/qent/sona/core/McpServerStatus.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/McpServerStatus.kt
@@ -1,0 +1,18 @@
+package io.qent.sona.core
+
+import dev.langchain4j.agent.tool.ToolSpecification
+
+/**
+ * Represents the current connection state of an MCP server.
+ */
+data class McpServerStatus(
+    val name: String,
+    val status: Status,
+    val tools: List<ToolSpecification>
+) {
+    sealed interface Status {
+        data object CONNECTING : Status
+        data object CONNECTED : Status
+        data class FAILED(val e: Exception) : Status
+    }
+}

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -1,12 +1,14 @@
 package io.qent.sona.core
 
 import dev.langchain4j.data.message.ChatMessage
+import kotlinx.coroutines.flow.StateFlow
 
 sealed class State {
     abstract val onNewChat: () -> Unit
     abstract val onOpenHistory: () -> Unit
     abstract val onOpenRoles: () -> Unit
     abstract val onOpenPresets: () -> Unit
+    abstract val onOpenServers: () -> Unit
 
     data class ChatState(
         val messages: List<ChatMessage>,
@@ -31,6 +33,7 @@ sealed class State {
         override val onOpenHistory: () -> Unit,
         override val onOpenRoles: () -> Unit,
         override val onOpenPresets: () -> Unit,
+        override val onOpenServers: () -> Unit,
     ) : State()
 
     data class ChatListState(
@@ -40,6 +43,7 @@ sealed class State {
         override val onNewChat: () -> Unit,
         override val onOpenRoles: () -> Unit,
         override val onOpenPresets: () -> Unit,
+        override val onOpenServers: () -> Unit,
     ) : State() {
         override val onOpenHistory = { }
     }
@@ -58,6 +62,7 @@ sealed class State {
         override val onOpenHistory: () -> Unit,
         override val onOpenRoles: () -> Unit,
         override val onOpenPresets: () -> Unit,
+        override val onOpenServers: () -> Unit,
     ) : State()
 
     data class PresetsState(
@@ -73,7 +78,18 @@ sealed class State {
         override val onNewChat: () -> Unit,
         override val onOpenHistory: () -> Unit,
         override val onOpenRoles: () -> Unit,
+        override val onOpenServers: () -> Unit,
     ) : State() {
         override val onOpenPresets = { }
+    }
+
+    data class ServersState(
+        val servers: StateFlow<List<McpServerStatus>>,
+        override val onNewChat: () -> Unit,
+        override val onOpenHistory: () -> Unit,
+        override val onOpenRoles: () -> Unit,
+        override val onOpenPresets: () -> Unit,
+    ) : State() {
+        override val onOpenServers = { }
     }
 }

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -101,6 +101,7 @@ class StateProvider(
             onOpenHistory = { scope.launch { showHistory() } },
             onOpenRoles = { scope.launch { showRoles() } },
             onOpenPresets = { scope.launch { showPresets() } },
+            onOpenServers = { scope.launch { showServers() } },
         )
     }
 
@@ -111,6 +112,7 @@ class StateProvider(
         onNewChat = { scope.launch { newChat() } },
         onOpenRoles = { scope.launch { showRoles() } },
         onOpenPresets = { scope.launch { showPresets() } },
+        onOpenServers = { scope.launch { showServers() } },
     )
 
     private fun createRolesState(): State.RolesState {
@@ -131,7 +133,8 @@ class StateProvider(
             onNewChat = { scope.launch { newChat() } },
             onOpenHistory = { scope.launch { showHistory() } },
             onOpenRoles = { },
-            onOpenPresets = { scope.launch { showPresets() } }
+            onOpenPresets = { scope.launch { showPresets() } },
+            onOpenServers = { scope.launch { showServers() } },
         )
     }
 
@@ -150,6 +153,10 @@ class StateProvider(
         presets = presetsRepository.load()
         if (presets.presets.isEmpty()) creatingPreset = true
         _state.emit(createPresetsState())
+    }
+
+    private suspend fun showServers() {
+        _state.emit(createServersState())
     }
 
     private suspend fun newChat() {
@@ -263,8 +270,17 @@ class StateProvider(
             onNewChat = { scope.launch { newChat() } },
             onOpenHistory = { scope.launch { showHistory() } },
             onOpenRoles = { scope.launch { showRoles() } },
+            onOpenServers = { scope.launch { showServers() } },
         )
     }
+
+    private fun createServersState(): State.ServersState = State.ServersState(
+        servers = mcpManager.servers,
+        onNewChat = { scope.launch { newChat() } },
+        onOpenHistory = { scope.launch { showHistory() } },
+        onOpenRoles = { scope.launch { showRoles() } },
+        onOpenPresets = { scope.launch { showPresets() } },
+    )
 
     private suspend fun selectChatPreset(idx: Int) {
         presets = presets.copy(active = idx)

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -67,6 +67,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
         onOpenHistory = {},
         onOpenRoles = {},
         onOpenPresets = {},
+        onOpenServers = {},
     )
 
     init {

--- a/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
+++ b/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
@@ -15,6 +15,7 @@ import io.qent.sona.services.ThemeService
 import io.qent.sona.ui.ChatPanel
 import io.qent.sona.ui.PresetsPanel
 import io.qent.sona.ui.RolesPanel
+import io.qent.sona.ui.ServersPanel
 import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.bridge.JewelComposePanel
 
@@ -32,6 +33,7 @@ class PluginToolWindowFactory : ToolWindowFactory, DumbAware {
                         is ChatListState -> ChatListPanel(s)
                         is RolesState -> RolesPanel(s)
                         is PresetsState -> PresetsPanel(s)
+                        is ServersState -> ServersPanel(s)
                     }
                 }
             },
@@ -46,6 +48,7 @@ class PluginToolWindowFactory : ToolWindowFactory, DumbAware {
                 ActionManager.getInstance().getAction("OpenHistoryAction"),
                 ActionManager.getInstance().getAction("OpenRolesAction"),
                 ActionManager.getInstance().getAction("OpenPresetsAction"),
+                ActionManager.getInstance().getAction("OpenServersAction"),
             )
         )
     }

--- a/src/main/kotlin/io/qent/sona/actions/CreateNewChatAction.kt
+++ b/src/main/kotlin/io/qent/sona/actions/CreateNewChatAction.kt
@@ -15,6 +15,7 @@ class CreateNewChatAction : AnAction("Create", "Create new chat", AllIcons.Gener
                 is State.ChatState -> if (messages.isNotEmpty()) onNewChat()
                 is State.RolesState -> onNewChat()
                 is State.PresetsState -> onNewChat()
+                is State.ServersState -> onNewChat()
             }
         }
     }

--- a/src/main/kotlin/io/qent/sona/actions/OpenServersAction.kt
+++ b/src/main/kotlin/io/qent/sona/actions/OpenServersAction.kt
@@ -1,0 +1,13 @@
+package io.qent.sona.actions
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
+import io.qent.sona.PluginStateFlow
+
+class OpenServersAction : AnAction("Servers", "Show MCP servers", AllIcons.Nodes.Folder) {
+    override fun actionPerformed(e: AnActionEvent) {
+        e.project?.service<PluginStateFlow>()?.lastState?.onOpenServers?.invoke()
+    }
+}

--- a/src/main/kotlin/io/qent/sona/ui/ServersPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ServersPanel.kt
@@ -1,0 +1,47 @@
+package io.qent.sona.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.qent.sona.core.McpServerStatus
+import io.qent.sona.core.State
+import org.jetbrains.jewel.ui.component.Text
+
+@Composable
+fun ServersPanel(state: State.ServersState) {
+    val servers by state.servers.collectAsState(emptyList())
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(SonaTheme.colors.Background)
+            .padding(8.dp)
+    ) {
+        LazyColumn(Modifier.fillMaxSize()) {
+            items(servers) { server ->
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp)
+                ) {
+                    Text(server.name, color = SonaTheme.colors.AiText, modifier = Modifier.weight(1f))
+                    val statusText = when (server.status) {
+                        is McpServerStatus.Status.CONNECTING -> "Connecting"
+                        is McpServerStatus.Status.CONNECTED -> "Connected"
+                        is McpServerStatus.Status.FAILED -> "Failed"
+                    }
+                    Text(statusText, color = SonaTheme.colors.AiText)
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,12 @@
                 text="Preset"
                 description="Edit LLM presets"
                 icon="AllIcons.General.Gear"/>
+
+        <action id="OpenServersAction"
+                class="io.qent.sona.actions.OpenServersAction"
+                text="Servers"
+                description="Show MCP servers"
+                icon="AllIcons.Nodes.Folder"/>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
## Summary
- track MCP server statuses with `StateFlow` in core
- expose a Servers panel listing server connection states
- add toolbar action to open Servers panel

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68923d0535ec8320800f293e6a3c5d60