### PR TITLE
feat: add server management panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ servers. Each entry supports `name`, `command`, `args`, `env`, `transport`, `url
 Currently `transport` may be `stdio` or `http`. Every server runs in its own coroutine so a failure does
 not affect the plugin. Tools provided by MCP servers require the same user confirmation as local tools.
 
-The tool window includes a **Servers** action listing all configured MCP servers together with their current
-connection status.
+The tool window includes a **Servers** action listing all configured MCP servers. Each server is shown as a card
+with a coloured status indicator – grey for disabled, red when a connection fails, yellow while connecting and
+green once connected and exposing tools. Clicking a card toggles the server on or off. A refresh button above
+the list reloads `sona.json` and reconnects previously enabled servers.
 
 ```json
 {

--- a/core/src/main/kotlin/io/qent/sona/core/McpServerStatus.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/McpServerStatus.kt
@@ -11,6 +11,8 @@ data class McpServerStatus(
     val tools: List<ToolSpecification>
 ) {
     sealed interface Status {
+        /** The server is turned off and no information is sent to the LLM. */
+        data object DISABLED : Status
         data object CONNECTING : Status
         data object CONNECTED : Status
         data class FAILED(val e: Exception) : Status

--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -85,6 +85,8 @@ sealed class State {
 
     data class ServersState(
         val servers: StateFlow<List<McpServerStatus>>,
+        val onToggleServer: (String) -> Unit,
+        val onReload: () -> Unit,
         override val onNewChat: () -> Unit,
         override val onOpenHistory: () -> Unit,
         override val onOpenRoles: () -> Unit,

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -276,6 +276,8 @@ class StateProvider(
 
     private fun createServersState(): State.ServersState = State.ServersState(
         servers = mcpManager.servers,
+        onToggleServer = { name -> mcpManager.toggle(name) },
+        onReload = { scope.launch { mcpManager.reload() } },
         onNewChat = { scope.launch { newChat() } },
         onOpenHistory = { scope.launch { showHistory() } },
         onOpenRoles = { scope.launch { showRoles() } },

--- a/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
@@ -7,9 +7,8 @@ import io.qent.sona.core.McpServersRepository
 
 class PluginMcpServersRepository(project: Project) : McpServersRepository {
     private val root = project.basePath ?: "/"
-    private val config = SonaConfig.load(root)
-
     override suspend fun list(): List<McpServerConfig> {
+        val config = SonaConfig.load(root)
         val servers = config?.mcpServers ?: return emptyList()
         return servers.mapNotNull { server ->
             val name = server.name ?: return@mapNotNull null

--- a/src/main/kotlin/io/qent/sona/ui/ServersPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/ServersPanel.kt
@@ -1,45 +1,69 @@
 package io.qent.sona.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import io.qent.sona.core.McpServerStatus
 import io.qent.sona.core.State
+import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
 
 @Composable
 fun ServersPanel(state: State.ServersState) {
     val servers by state.servers.collectAsState(emptyList())
+    val listState = rememberLazyListState()
     Column(
         Modifier
             .fillMaxSize()
             .background(SonaTheme.colors.Background)
             .padding(8.dp)
     ) {
-        LazyColumn(Modifier.fillMaxSize()) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            ActionButton(onClick = state.onReload) { Text("\u27f3") }
+        }
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        ) {
             items(servers) { server ->
                 Row(
                     Modifier
                         .fillMaxWidth()
                         .padding(vertical = 4.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(SonaTheme.colors.AiBubble)
+                        .clickable { state.onToggleServer(server.name) }
+                        .padding(vertical = 6.dp, horizontal = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(server.name, color = SonaTheme.colors.AiText, modifier = Modifier.weight(1f))
-                    val statusText = when (server.status) {
-                        is McpServerStatus.Status.CONNECTING -> "Connecting"
-                        is McpServerStatus.Status.CONNECTED -> "Connected"
-                        is McpServerStatus.Status.FAILED -> "Failed"
+                    val color = when (server.status) {
+                        is McpServerStatus.Status.DISABLED -> Color.Gray
+                        is McpServerStatus.Status.FAILED -> Color(0xFFF44336)
+                        is McpServerStatus.Status.CONNECTING -> Color(0xFFFFC107)
+                        is McpServerStatus.Status.CONNECTED -> Color(0xFF4CAF50)
                     }
-                    Text(statusText, color = SonaTheme.colors.AiText)
+                    Box(
+                        Modifier
+                            .size(12.dp)
+                            .clip(CircleShape)
+                            .background(color)
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- show MCP servers as clickable cards with color-coded status and refresh
- support toggling and reloading servers at runtime

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6892552f8cf08320a42636445e2694e1