### PR TITLE
Resolve npx path for MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ The available tools let the model read the focused file, read any file by absolu
 
 The same configuration file can also include an `mcpServers` array specifying Model Context Protocol
 servers. Each entry supports `name`, `command`, `args`, `env`, `transport`, `url`, `cwd` and `headers` fields.
-Currently `transport` may be `stdio` or `http`. Every server runs in its own coroutine so a failure does
+When `command` is `npx`, Sona resolves the absolute path to the `npx` executable by checking typical
+installation locations for the current operating system before launching the server. Currently
+`transport` may be `stdio` or `http`. Every server runs in its own coroutine so a failure does
 not affect the plugin. Tools provided by MCP servers require the same user confirmation as local tools.
 
 The tool window includes a **Servers** action listing all configured MCP servers together with their current

--- a/core/src/main/kotlin/io/qent/sona/core/McpConnectionManager.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/McpConnectionManager.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.io.File
 
 class McpConnectionManager(
     private val repository: McpServersRepository,
@@ -75,7 +76,7 @@ class McpConnectionManager(
         val transport = when (config.transport?.lowercase()) {
             "stdio" -> {
                 val cmd = buildList {
-                    config.command?.let { add(it) }
+                    resolveCommand(config.command)?.let { add(it) }
                     config.args?.let { addAll(it) }
                 }
                 if (cmd.isEmpty()) return null
@@ -99,6 +100,53 @@ class McpConnectionManager(
             .key(config.name)
             .transport(transport)
             .build()
+    }
+
+    private fun resolveCommand(command: String?): String? {
+        command ?: return null
+        return if (command.equals("npx", ignoreCase = true)) {
+            findNpxExecutable() ?: command
+        } else {
+            command
+        }
+    }
+
+    private fun findNpxExecutable(): String? {
+        val os = System.getProperty("os.name").lowercase()
+        val home = System.getProperty("user.home")
+        val isWindows = os.contains("win")
+        val names = if (isWindows) listOf("npx.cmd", "npx.exe") else listOf("npx")
+        val candidates = mutableListOf<File>()
+
+        System.getenv("PATH")?.split(File.pathSeparator)?.forEach { dir ->
+            names.forEach { name -> candidates += File(dir, name) }
+        }
+
+        if (isWindows) {
+            candidates += File(home, "AppData/Local/Programs/npm/npx.cmd")
+            candidates += File(home, "AppData/Roaming/npm/npx.cmd")
+            candidates += File("C:/Program Files/nodejs/npx.cmd")
+            candidates += File("C:/Program Files (x86)/nodejs/npx.cmd")
+        } else if (os.contains("mac") || os.contains("darwin")) {
+            candidates += File("/opt/homebrew/bin/npx")
+            candidates += File("/usr/local/bin/npx")
+        } else {
+            candidates += File("/usr/bin/npx")
+            candidates += File("/usr/local/bin/npx")
+        }
+
+        val nvmDir = File(home, ".nvm/versions/node")
+        if (nvmDir.isDirectory) {
+            nvmDir.listFiles()?.forEach { version ->
+                val bin = File(version, "bin/npx")
+                if (bin.exists()) candidates += bin
+            }
+        }
+
+        val asdfShim = File(home, ".asdf/shims/npx")
+        if (asdfShim.exists()) candidates += asdfShim
+
+        return candidates.firstOrNull { it.exists() && it.canExecute() }?.absolutePath
     }
 
     fun hasTool(name: String): Boolean = tools.containsKey(name)


### PR DESCRIPTION
## Summary
- resolve `npx` in MCP server configs to an absolute path
- document automatic `npx` resolution in README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68925862e1c08320b1eefbcdab3292d1