### PR TITLE
Refactor ChatFlow to AiService token stream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - A tool is available to switch the active role between Architect and Code.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
   environment (OS, IDE, Java, Python, Node.js, file extension statistics, build systems) and is prepended to every LLM request.
+- ChatFlow leverages langchain4j `AiService` and `TokenStream` to emit partial responses and tool events via streaming callbacks.
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Chat with various language models directly from a side panel in your IDE. The ch
 history is persisted in IDE storage so it survives restarts. Connection details are
 managed as presets where you choose a provider, model, API endpoint and token. Responses stream
 gradually so you can watch them being generated in real time and stop the stream at any moment
-to keep the partial reply.
+to keep the partial reply. Under the hood the core relies on langchain4j `AiService` and
+`TokenStream` to deliver partial responses and tool execution events via streaming callbacks.
 
 <!-- Plugin description -->
 Chat with Anthropic, OpenAI, Deepseek or Gemini models right inside your IDE. The chat history is stored persistently so

--- a/core/src/main/kotlin/io/qent/sona/core/ChatRepositoryChatMemoryStore.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/ChatRepositoryChatMemoryStore.kt
@@ -1,0 +1,33 @@
+package io.qent.sona.core
+
+import dev.langchain4j.data.message.ChatMessage
+import dev.langchain4j.memory.ChatMemory
+import kotlinx.coroutines.runBlocking
+
+/**
+ * ChatMemory backed by [ChatRepository]. It loads existing messages
+ * synchronously and stores new ones only in memory. ChatFlow persists
+ * messages explicitly so this memory primarily serves the AI service
+ * during a request.
+ */
+class ChatRepositoryChatMemoryStore(
+    private val chatRepository: ChatRepository,
+    private val chatId: String,
+) : ChatMemory {
+
+    private val messages: MutableList<ChatMessage> = runBlocking {
+        chatRepository.loadMessages(chatId).map { it.message }.toMutableList()
+    }
+
+    override fun id(): Any = chatId
+
+    override fun add(message: ChatMessage) {
+        messages += message
+    }
+
+    override fun messages(): MutableList<ChatMessage> = messages
+
+    override fun clear() {
+        messages.clear()
+    }
+}

--- a/core/src/main/kotlin/io/qent/sona/core/SonaAiService.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/SonaAiService.kt
@@ -1,0 +1,12 @@
+package io.qent.sona.core
+
+import dev.langchain4j.service.MemoryId
+import dev.langchain4j.service.TokenStream
+import dev.langchain4j.service.UserMessage
+
+interface SonaAiService {
+    fun chat(
+        @MemoryId chatId: String,
+        @UserMessage message: String
+    ): TokenStream
+}

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -43,20 +43,6 @@ class StateProvider(
             _state.emit(createChatState(chat))
         }.launchIn(scope)
 
-        chatFlow.buffer(10).filterNot { it.isStreaming }
-            .map { it.messages.lastOrNull() }
-            .filterNotNull()
-            .distinctUntilChanged()
-            .onEach { message ->
-                chatRepository.addMessage(
-                    message.chatId,
-                    message.message,
-                    message.model,
-                    message.tokenUsage
-                )
-            }
-            .launchIn(scope)
-
         scope.launch {
             roles = rolesRepository.load()
             presets = presetsRepository.load()


### PR DESCRIPTION
## Summary
- integrate SonaAiService with TokenStream API
- replace manual streaming in ChatFlow with AiService and tool executors
- document AiService streaming callbacks

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6892f510d5448320ac164756d0022b2e