### PR TITLE
feat: separate UI and repository data models

### DIFF
--- a/core/src/main/kotlin/io/qent/sona/core/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/State.kt
@@ -1,7 +1,22 @@
 package io.qent.sona.core
 
-import dev.langchain4j.data.message.ChatMessage
 import kotlinx.coroutines.flow.StateFlow
+
+sealed interface UiMessage {
+    val text: String
+
+    data class User(override val text: String) : UiMessage
+    data class Ai(override val text: String) : UiMessage
+    data class Tool(override val text: String) : UiMessage
+    data class System(override val text: String) : UiMessage
+}
+
+data class UiChatSummary(
+    val id: String,
+    val firstMessage: String,
+    val messages: Int,
+    val createdAt: Long,
+)
 
 sealed class State {
     abstract val onNewChat: () -> Unit
@@ -11,7 +26,7 @@ sealed class State {
     abstract val onOpenServers: () -> Unit
 
     data class ChatState(
-        val messages: List<ChatMessage>,
+        val messages: List<UiMessage>,
         val totalTokenUsage: TokenUsageInfo,
         val lastTokenUsage: TokenUsageInfo,
         val isSending: Boolean,
@@ -37,7 +52,7 @@ sealed class State {
     ) : State()
 
     data class ChatListState(
-        val chats: List<ChatSummary>,
+        val chats: List<UiChatSummary>,
         val onOpenChat: (String) -> Unit,
         val onDeleteChat: (String) -> Unit,
         override val onNewChat: () -> Unit,

--- a/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/StateProvider.kt
@@ -2,6 +2,8 @@ package io.qent.sona.core
 
 import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.ToolExecutionResultMessage
 import dev.langchain4j.model.chat.StreamingChatModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -62,7 +64,7 @@ class StateProvider(
         val lastAi = chat.messages.lastOrNull { it.message is AiMessage }
         val lastUsage = lastAi?.tokenUsage ?: TokenUsageInfo()
         return State.ChatState(
-            messages = chat.messages.map { it.message },
+            messages = chat.messages.map { it.toUiMessage() },
             totalTokenUsage = chat.tokenUsage,
             lastTokenUsage = lastUsage,
             isSending = chat.requestInProgress,
@@ -92,7 +94,7 @@ class StateProvider(
     }
 
     private fun createListState(chats: List<ChatSummary>) = State.ChatListState(
-        chats = chats.filter { it.messages != 0 },
+        chats = chats.filter { it.messages != 0 }.map { it.toUi() },
         onOpenChat = { id -> scope.launch { openChat(id) } },
         onDeleteChat = { id -> scope.launch { deleteChat(id) } },
         onNewChat = { scope.launch { newChat() } },
@@ -318,3 +320,14 @@ class StateProvider(
         _state.emit(createPresetsState())
     }
 }
+
+private fun ChatRepositoryMessage.toUiMessage(): UiMessage = when (val m = message) {
+    is AiMessage -> UiMessage.Ai(m.text().orEmpty())
+    is UserMessage -> UiMessage.User(m.singleText().trim())
+    is SystemMessage -> UiMessage.System(m.text())
+    is ToolExecutionResultMessage -> UiMessage.Tool(m.text())
+    else -> UiMessage.System(m.toString())
+}
+
+private fun ChatSummary.toUi(): UiChatSummary =
+    UiChatSummary(id, firstMessage, messages, createdAt)

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -11,6 +11,7 @@ import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
 import io.qent.sona.core.*
+import io.qent.sona.core.UiMessage
 import io.qent.sona.tools.PluginExternalTools
 import io.qent.sona.repositories.PluginChatRepository
 import io.qent.sona.repositories.PluginPresetsRepository
@@ -45,7 +46,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
     private val externalTools = PluginExternalTools(project)
 
     var lastState: State = State.ChatState(
-        messages = emptyList(),
+        messages = emptyList<UiMessage>(),
         totalTokenUsage = TokenUsageInfo(),
         lastTokenUsage = TokenUsageInfo(),
         isSending = false,


### PR DESCRIPTION
## Summary
- add UiMessage and UiChatSummary models for UI layer
- map repository messages and summaries to UI models in StateProvider
- update ChatPanel and PluginStateFlow to use new UI models
- refactor UiMessage into a sealed interface instead of using a role field

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68935a392fb88320b566d5c5ce541ee2