### PR TITLE
Highlight markdown code blocks using IDE editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ that message and all following messages from both the chat view and persistent
 history.
 
 Chat messages are now selectable so you can highlight and copy any portion of
-the text directly.
+the text directly. Code blocks render using the IDE editor component, providing
+full syntax highlighting.
 
 ## Architecture Overview
 

--- a/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
+++ b/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
@@ -29,7 +29,7 @@ class PluginToolWindowFactory : ToolWindowFactory, DumbAware {
                 val state = pluginStateFlow.collectAsState(pluginStateFlow.lastState)
                 SonaTheme(dark = dark) {
                     when (val s = state.value) {
-                        is ChatState -> ChatPanel(s)
+                        is ChatState -> ChatPanel(project, s)
                         is ChatListState -> ChatListPanel(s)
                         is RolesState -> RolesPanel(s)
                         is PresetsState -> PresetsPanel(s)

--- a/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.intellij.openapi.util.IconLoader
+import com.intellij.openapi.project.Project
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.rememberMarkdownState
@@ -42,7 +43,7 @@ import io.qent.sona.ui.SonaTheme
 import javax.swing.Icon
 
 @Composable
-fun ChatPanel(state: ChatState) {
+fun ChatPanel(project: Project, state: ChatState) {
     Column(
         Modifier
             .fillMaxSize()
@@ -52,14 +53,14 @@ fun ChatPanel(state: ChatState) {
         Box(
             Modifier.weight(1f)
         ) {
-            Messages(state)
+            Messages(project, state)
         }
         ChatInput(state)
     }
 }
 
 @Composable
-private fun Messages(state: ChatState, modifier: Modifier = Modifier) {
+private fun Messages(project: Project, state: ChatState, modifier: Modifier = Modifier) {
     val listState = rememberLazyListState()
     LazyColumn(
         state = listState,
@@ -77,9 +78,9 @@ private fun Messages(state: ChatState, modifier: Modifier = Modifier) {
                     val bottom: (@Composable () -> Unit)? = if (state.toolRequest && index == state.messages.lastIndex) {
                         @Composable { ToolPermissionButtons(state.onAllowTool, state.onAlwaysAllowTool, state.onDenyTool) }
                     } else null
-                    MessageBubble(message, isUser = false, bottomContent = bottom, onDelete = { state.onDeleteFrom(index) })
+                    MessageBubble(project, message, isUser = false, bottomContent = bottom, onDelete = { state.onDeleteFrom(index) })
                 } else if (message is UserMessage) {
-                    MessageBubble(message, isUser = true, onDelete = { state.onDeleteFrom(index) })
+                    MessageBubble(project, message, isUser = true, onDelete = { state.onDeleteFrom(index) })
                 }
             }
             Spacer(Modifier.height(2.dp))
@@ -94,7 +95,7 @@ private fun Messages(state: ChatState, modifier: Modifier = Modifier) {
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun MessageBubble(message: Any, isUser: Boolean, bottomContent: (@Composable () -> Unit)? = null, onDelete: () -> Unit) {
+fun MessageBubble(project: Project, message: Any, isUser: Boolean, bottomContent: (@Composable () -> Unit)? = null, onDelete: () -> Unit) {
     if (message is AiMessage) {
         if (message.text().isNullOrEmpty()) return
     }
@@ -139,8 +140,8 @@ fun MessageBubble(message: Any, isUser: Boolean, bottomContent: (@Composable () 
                             colors = SonaTheme.markdownColors,
                             typography = SonaTheme.markdownTypography,
                             components = markdownComponents(
-                                codeFence = { CopyableCodeBlock(it, true) },
-                                codeBlock = { CopyableCodeBlock(it, false) },
+                                codeFence = { CopyableCodeBlock(project, it, true) },
+                                codeBlock = { CopyableCodeBlock(project, it, false) },
                             ),
                         )
                     } else if (message is UserMessage) {

--- a/src/main/kotlin/io/qent/sona/ui/chat/CopyableCodeBlock.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/CopyableCodeBlock.kt
@@ -2,6 +2,8 @@ package io.qent.sona.ui.chat
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -9,39 +11,49 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.SwingPanel
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
+import com.intellij.lang.Language
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.fileTypes.PlainTextFileType
+import com.intellij.openapi.project.Project
+import com.intellij.ui.EditorTextField
 import com.mikepenz.markdown.compose.components.MarkdownComponentModel
 import com.mikepenz.markdown.compose.elements.MarkdownCodeBlock
 import com.mikepenz.markdown.compose.elements.MarkdownCodeFence
 import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.ui.component.IconButton
+import kotlin.math.max
 
 /**
  * Renders a markdown code block with a copy button overlay.
  */
 @Composable
-fun CopyableCodeBlock(model: MarkdownComponentModel, fence: Boolean) {
+fun CopyableCodeBlock(project: Project, model: MarkdownComponentModel, fence: Boolean) {
     val clipboard = LocalClipboardManager.current
     val extractedCode = remember { mutableStateOf("") }
 
     Box {
         if (fence) {
-            MarkdownCodeFence(model.content, model.node, style = model.typography.code) { code, _, _ ->
+            MarkdownCodeFence(model.content, model.node, style = model.typography.code) { code: String, lang: String?, _ ->
                 extractedCode.value = code
-                MarkdownCodeFence(model.content, model.node, style = model.typography.code)
+                CodeEditor(project, code, lang)
             }
         } else {
-            MarkdownCodeBlock(model.content, model.node, style = model.typography.code) { code, _, _ ->
+            MarkdownCodeBlock(model.content, model.node, style = model.typography.code) { code: String, lang: String?, _ ->
                 extractedCode.value = code
-                MarkdownCodeBlock(model.content, model.node, style = model.typography.code)
+                CodeEditor(project, code, lang)
             }
         }
-        IconButton(onClick = {
-            clipboard.setText(AnnotatedString(extractedCode.value)
-        ) }, modifier = Modifier.align(Alignment.TopEnd).padding(top = 12.dp, end = 4.dp)) {
+        IconButton(
+            onClick = { clipboard.setText(AnnotatedString(extractedCode.value)) },
+            modifier = Modifier.align(Alignment.TopEnd).padding(top = 12.dp, end = 4.dp)
+        ) {
             Image(
                 painter = loadIcon("/icons/copy.svg"),
                 contentDescription = "Copy code",
@@ -50,4 +62,23 @@ fun CopyableCodeBlock(model: MarkdownComponentModel, fence: Boolean) {
             )
         }
     }
+}
+
+@Composable
+private fun CodeEditor(project: Project, code: String, language: String?) {
+    val fileType: FileType = remember(language) {
+        language?.let {
+            Language.findLanguageByID(it)?.associatedFileType
+                ?: FileTypeManager.getInstance().getFileTypeByExtension(it)
+        } ?: PlainTextFileType.INSTANCE
+    }
+    val document = remember(code) { EditorFactory.getInstance().createDocument(code) }
+    val lines = remember(code) { max(1, code.lineSequence().count()) }
+    val lineHeight = 20.dp
+    SwingPanel(
+        factory = { EditorTextField(document, project, fileType, true, false) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(lineHeight * lines)
+    )
 }


### PR DESCRIPTION
## Summary
- render markdown code blocks using IntelliJ's `EditorTextField` for full IDE syntax highlighting
- pass the current `Project` through chat UI so code blocks can access file types
- document that code blocks now use the IDE editor component
- compute a height based on line count so code blocks are visible

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689369fbcbdc8320a5ffa809291bbc1c