### PR TITLE
Highlight markdown code blocks using IDE editor

### DIFF
--- a/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
@@ -89,7 +89,7 @@ private fun Messages(project: Project, state: ChatState, modifier: Modifier = Mo
                 if (message is UiMessage.Ai || message is UiMessage.User) {
                     MessageBubble(project, message, bottomContent = bottom, onDelete = { state.onDeleteFrom(index) })
                 } else if (message is UiMessage.Tool) {
-                    ToolMessageBubble(project, message, onDelete = { state.onDeleteFrom(index) })
+                    ToolMessageBubble(message, onDelete = { state.onDeleteFrom(index) })
                 }
             }
             Spacer(Modifier.height(2.dp))


### PR DESCRIPTION
## Summary
- render markdown code blocks using IntelliJ's `EditorTextField` for full IDE syntax highlighting
- pass the current `Project` through chat UI so code blocks can access file types
- document that code blocks now use the IDE editor component

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689369fbcbdc8320a5ffa809291bbc1c