### PR TITLE
refactor: reorganize core packages

### DIFF
--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatFlow.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.chat
 
 import com.google.gson.Gson
 import dev.langchain4j.agent.tool.ToolExecutionRequest
@@ -19,6 +19,15 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.CancellableContinuation
 import kotlin.coroutines.resume
+import io.qent.sona.core.mcp.McpConnectionManager
+import io.qent.sona.core.model.TokenUsageInfo
+import io.qent.sona.core.model.SonaAiService
+import io.qent.sona.core.model.toInfo
+import io.qent.sona.core.repositories.ChatRepositoryChatMemoryStore
+import io.qent.sona.core.presets.Preset
+import io.qent.sona.core.presets.PresetsRepository
+import io.qent.sona.core.roles.RolesRepository
+import io.qent.sona.core.tools.Tools
 
 
 data class Chat(

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatRepository.kt
@@ -1,6 +1,7 @@
-package io.qent.sona.core
+package io.qent.sona.core.chat
 
 import dev.langchain4j.data.message.ChatMessage
+import io.qent.sona.core.model.TokenUsageInfo
 
 /**
  * Repository for storing user chats and messages.

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpConnectionManager.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpConnectionManager.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.mcp
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest as AgentToolExecutionRequest
 import dev.langchain4j.mcp.client.DefaultMcpClient

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpServerStatus.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpServerStatus.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.mcp
 
 import dev.langchain4j.agent.tool.ToolSpecification
 

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpServersRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpServersRepository.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.mcp
 
 data class McpServerConfig(
     val name: String,

--- a/core/src/main/kotlin/io/qent/sona/core/model/SonaAiService.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/model/SonaAiService.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.model
 
 import dev.langchain4j.service.MemoryId
 import dev.langchain4j.service.TokenStream

--- a/core/src/main/kotlin/io/qent/sona/core/model/TokenUsageInfo.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/model/TokenUsageInfo.kt
@@ -1,8 +1,9 @@
-package io.qent.sona.core
+package io.qent.sona.core.model
 
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage
 import dev.langchain4j.model.openai.OpenAiTokenUsage
 import dev.langchain4j.model.output.TokenUsage
+import io.qent.sona.core.presets.LlmModel
 
 /**
  * Container for token usage statistics including cached tokens.

--- a/core/src/main/kotlin/io/qent/sona/core/permissions/FileInfo.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/permissions/FileInfo.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.permissions
 
 data class FileInfo(
     val path: String,

--- a/core/src/main/kotlin/io/qent/sona/core/permissions/FilePermissionManager.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/permissions/FilePermissionManager.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.permissions
 
 class FilePermissionManager(
     private val repository: FilePermissionsRepository,

--- a/core/src/main/kotlin/io/qent/sona/core/permissions/FilePermissionsRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/permissions/FilePermissionsRepository.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.permissions
 
 interface FilePermissionsRepository {
     val whitelist: List<String>

--- a/core/src/main/kotlin/io/qent/sona/core/presets/PresetsRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/presets/PresetsRepository.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.presets
 
 /** Information about a specific LLM model. */
 data class LlmModel(

--- a/core/src/main/kotlin/io/qent/sona/core/repositories/ChatRepositoryChatMemoryStore.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/repositories/ChatRepositoryChatMemoryStore.kt
@@ -1,7 +1,8 @@
-package io.qent.sona.core
+package io.qent.sona.core.repositories
 
 import dev.langchain4j.data.message.ChatMessage
 import dev.langchain4j.memory.ChatMemory
+import io.qent.sona.core.chat.ChatRepository
 import kotlinx.coroutines.runBlocking
 
 /**

--- a/core/src/main/kotlin/io/qent/sona/core/roles/DefaultRoles.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/roles/DefaultRoles.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.roles
 
 enum class DefaultRoles(val displayName: String) {
     ARCHITECT("\uD83C\uDFD7\uFE0F  Architect"),

--- a/core/src/main/kotlin/io/qent/sona/core/roles/RolesRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/roles/RolesRepository.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.roles
 
 data class Role(val name: String, val text: String)
 

--- a/core/src/main/kotlin/io/qent/sona/core/settings/Settings.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/settings/Settings.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.settings
 
 data class Settings(
     val ignoreHttpsErrors: Boolean

--- a/core/src/main/kotlin/io/qent/sona/core/settings/SettingsRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/settings/SettingsRepository.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.settings
 
 interface SettingsRepository {
     suspend fun load(): Settings

--- a/core/src/main/kotlin/io/qent/sona/core/state/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/State.kt
@@ -1,7 +1,11 @@
-package io.qent.sona.core
+package io.qent.sona.core.state
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest
 import kotlinx.coroutines.flow.StateFlow
+import io.qent.sona.core.model.TokenUsageInfo
+import io.qent.sona.core.presets.Presets
+import io.qent.sona.core.presets.Preset
+import io.qent.sona.core.mcp.McpServerStatus
 
 sealed interface UiMessage {
     val text: String

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.state
 
 import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.data.message.AiMessage
@@ -9,6 +9,28 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import io.qent.sona.core.chat.Chat
+import io.qent.sona.core.chat.ChatFlow
+import io.qent.sona.core.chat.ChatRepository
+import io.qent.sona.core.chat.ChatRepositoryMessage
+import io.qent.sona.core.chat.ChatSummary
+import io.qent.sona.core.mcp.McpConnectionManager
+import io.qent.sona.core.mcp.McpServersRepository
+import io.qent.sona.core.model.TokenUsageInfo
+import io.qent.sona.core.permissions.FilePermissionManager
+import io.qent.sona.core.permissions.FilePermissionsRepository
+import io.qent.sona.core.presets.Preset
+import io.qent.sona.core.presets.Presets
+import io.qent.sona.core.presets.PresetsRepository
+import io.qent.sona.core.roles.Roles
+import io.qent.sona.core.roles.RolesRepository
+import io.qent.sona.core.roles.DefaultRoles
+import io.qent.sona.core.roles.Role
+import io.qent.sona.core.presets.LlmProvider
+import io.qent.sona.core.tools.DefaultInternalTools
+import io.qent.sona.core.tools.ExternalTools
+import io.qent.sona.core.tools.Tools
+import io.qent.sona.core.tools.ToolsInfoDecorator
 
 
 class StateProvider(

--- a/core/src/main/kotlin/io/qent/sona/core/tools/DefaultInternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/DefaultInternalTools.kt
@@ -1,7 +1,8 @@
-package io.qent.sona.core
+package io.qent.sona.core.tools
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import io.qent.sona.core.roles.DefaultRoles
 
 class DefaultInternalTools(
     private val scope: CoroutineScope,

--- a/core/src/main/kotlin/io/qent/sona/core/tools/ExternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/ExternalTools.kt
@@ -1,4 +1,6 @@
-package io.qent.sona.core
+package io.qent.sona.core.tools
+
+import io.qent.sona.core.permissions.FileInfo
 
 interface ExternalTools {
     fun getFocusedFileText(): FileInfo?

--- a/core/src/main/kotlin/io/qent/sona/core/tools/InternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/InternalTools.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.tools
 
 interface InternalTools {
     fun switchToArchitect(): String

--- a/core/src/main/kotlin/io/qent/sona/core/tools/Tools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/Tools.kt
@@ -1,4 +1,4 @@
-package io.qent.sona.core
+package io.qent.sona.core.tools
 
 interface Tools : InternalTools {
     fun getFocusedFileText(): String

--- a/core/src/main/kotlin/io/qent/sona/core/tools/ToolsInfoDecorator.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/ToolsInfoDecorator.kt
@@ -1,6 +1,7 @@
-package io.qent.sona.core
+package io.qent.sona.core.tools
 
 import dev.langchain4j.agent.tool.Tool
+import io.qent.sona.core.permissions.FilePermissionManager
 
 class ToolsInfoDecorator(
     private val internalTools: InternalTools,

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -10,8 +10,12 @@ import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
-import io.qent.sona.core.*
-import io.qent.sona.core.UiMessage
+import io.qent.sona.core.model.TokenUsageInfo
+import io.qent.sona.core.presets.LlmProvider
+import io.qent.sona.core.presets.Presets
+import io.qent.sona.core.state.State
+import io.qent.sona.core.state.StateProvider
+import io.qent.sona.core.state.UiMessage
 import io.qent.sona.tools.PluginExternalTools
 import io.qent.sona.repositories.PluginChatRepository
 import io.qent.sona.repositories.PluginPresetsRepository
@@ -19,7 +23,6 @@ import io.qent.sona.repositories.PluginRolesRepository
 import io.qent.sona.repositories.PluginSettingsRepository
 import io.qent.sona.repositories.PluginFilePermissionsRepository
 import io.qent.sona.repositories.PluginMcpServersRepository
-import io.qent.sona.core.FilePermissionManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
+++ b/src/main/kotlin/io/qent/sona/PluginToolWindowFactory.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
-import io.qent.sona.core.State.*
+import io.qent.sona.core.state.State.*
 import io.qent.sona.services.ThemeService
 import io.qent.sona.ui.chat.ChatPanel
 import io.qent.sona.ui.presets.PresetsPanel

--- a/src/main/kotlin/io/qent/sona/actions/CreateNewChatAction.kt
+++ b/src/main/kotlin/io/qent/sona/actions/CreateNewChatAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
 import io.qent.sona.PluginStateFlow
-import io.qent.sona.core.State
+import io.qent.sona.core.state.State
 
 class CreateNewChatAction : AnAction("Create", "Create new chat", AllIcons.General.Add) {
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/io/qent/sona/repositories/PluginChatRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginChatRepository.kt
@@ -8,10 +8,10 @@ import dev.langchain4j.data.message.ChatMessage
 import dev.langchain4j.data.message.ChatMessageDeserializer
 import dev.langchain4j.data.message.ChatMessageSerializer
 import dev.langchain4j.data.message.UserMessage
-import io.qent.sona.core.ChatRepository
-import io.qent.sona.core.ChatRepositoryMessage
-import io.qent.sona.core.ChatSummary
-import io.qent.sona.core.TokenUsageInfo
+import io.qent.sona.core.chat.ChatRepository
+import io.qent.sona.core.chat.ChatRepositoryMessage
+import io.qent.sona.core.chat.ChatSummary
+import io.qent.sona.core.model.TokenUsageInfo
 import java.util.*
 
 @Service

--- a/src/main/kotlin/io/qent/sona/repositories/PluginFilePermissionsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginFilePermissionsRepository.kt
@@ -2,7 +2,7 @@ package io.qent.sona.repositories
 
 import com.intellij.openapi.project.Project
 import io.qent.sona.config.SonaConfig
-import io.qent.sona.core.FilePermissionsRepository
+import io.qent.sona.core.permissions.FilePermissionsRepository
 
 class PluginFilePermissionsRepository(project: Project) : FilePermissionsRepository {
     private val root = project.basePath ?: "/"

--- a/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
@@ -2,8 +2,8 @@ package io.qent.sona.repositories
 
 import com.intellij.openapi.project.Project
 import io.qent.sona.config.SonaConfig
-import io.qent.sona.core.McpServerConfig
-import io.qent.sona.core.McpServersRepository
+import io.qent.sona.core.mcp.McpServerConfig
+import io.qent.sona.core.mcp.McpServersRepository
 
 private val JETBRAINS_MCP_ARGS = listOf("-y", "@jetbrains/mcp-proxy")
 

--- a/src/main/kotlin/io/qent/sona/repositories/PluginPresetsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginPresetsRepository.kt
@@ -4,10 +4,10 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import io.qent.sona.core.LlmProvider
-import io.qent.sona.core.Preset
-import io.qent.sona.core.Presets
-import io.qent.sona.core.PresetsRepository
+import io.qent.sona.core.presets.LlmProvider
+import io.qent.sona.core.presets.Preset
+import io.qent.sona.core.presets.Presets
+import io.qent.sona.core.presets.PresetsRepository
 
 @Service
 @State(name = "PluginPresets", storages = [Storage("presets.xml")])

--- a/src/main/kotlin/io/qent/sona/repositories/PluginRolesRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginRolesRepository.kt
@@ -4,10 +4,10 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import io.qent.sona.core.Role
-import io.qent.sona.core.Roles
-import io.qent.sona.core.RolesRepository
-import io.qent.sona.core.DefaultRoles
+import io.qent.sona.core.roles.Role
+import io.qent.sona.core.roles.Roles
+import io.qent.sona.core.roles.RolesRepository
+import io.qent.sona.core.roles.DefaultRoles
 
 @Service
 @State(name = "PluginRoles", storages = [Storage("roles.xml")])

--- a/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
@@ -4,8 +4,8 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import io.qent.sona.core.Settings
-import io.qent.sona.core.SettingsRepository
+import io.qent.sona.core.settings.Settings
+import io.qent.sona.core.settings.SettingsRepository
 
 @Service
 @State(name = "PluginSettings", storages = [Storage("plugin_settings.xml")])

--- a/src/main/kotlin/io/qent/sona/tools/PluginExternalTools.kt
+++ b/src/main/kotlin/io/qent/sona/tools/PluginExternalTools.kt
@@ -2,8 +2,8 @@ package io.qent.sona.tools
 
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
-import io.qent.sona.core.ExternalTools
-import io.qent.sona.core.FileInfo
+import io.qent.sona.core.tools.ExternalTools
+import io.qent.sona.core.permissions.FileInfo
 import java.nio.file.Files
 import java.nio.file.Paths
 

--- a/src/main/kotlin/io/qent/sona/ui/chat/ChatHeader.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/ChatHeader.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.qent.sona.core.State.ChatState
-import io.qent.sona.core.cost
+import io.qent.sona.core.state.State.ChatState
+import io.qent.sona.core.model.cost
 import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.ui.component.Text
 

--- a/src/main/kotlin/io/qent/sona/ui/chat/ChatInput.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/ChatInput.kt
@@ -40,8 +40,8 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.qent.sona.core.DefaultRoles
-import io.qent.sona.core.State.ChatState
+import io.qent.sona.core.roles.DefaultRoles
+import io.qent.sona.core.state.State.ChatState
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
 import androidx.compose.runtime.*

--- a/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
@@ -34,8 +34,8 @@ import com.intellij.openapi.project.Project
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.rememberMarkdownState
-import io.qent.sona.core.State.ChatState
-import io.qent.sona.core.UiMessage
+import io.qent.sona.core.state.State.ChatState
+import io.qent.sona.core.state.UiMessage
 import io.qent.sona.PluginStateFlow
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text

--- a/src/main/kotlin/io/qent/sona/ui/history/ChatListPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/history/ChatListPanel.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.qent.sona.core.State.ChatListState
+import io.qent.sona.core.state.State.ChatListState
 import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text

--- a/src/main/kotlin/io/qent/sona/ui/mcp/ServersPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/mcp/ServersPanel.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.qent.sona.core.McpServerStatus
-import io.qent.sona.core.State
+import io.qent.sona.core.mcp.McpServerStatus
+import io.qent.sona.core.state.State
 import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text

--- a/src/main/kotlin/io/qent/sona/ui/presets/PresetsPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/presets/PresetsPanel.kt
@@ -14,9 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import io.qent.sona.core.LlmProvider
-import io.qent.sona.core.Preset
-import io.qent.sona.core.State
+import io.qent.sona.core.presets.LlmProvider
+import io.qent.sona.core.presets.Preset
+import io.qent.sona.core.state.State
 import io.qent.sona.ui.DropdownSelector
 import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi

--- a/src/main/kotlin/io/qent/sona/ui/roles/RolesPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/roles/RolesPanel.kt
@@ -11,8 +11,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import io.qent.sona.core.DefaultRoles
-import io.qent.sona.core.State.RolesState
+import io.qent.sona.core.roles.DefaultRoles
+import io.qent.sona.core.state.State.RolesState
 import io.qent.sona.ui.DropdownSelector
 import io.qent.sona.ui.SonaTheme
 import org.jetbrains.jewel.ui.component.ActionButton


### PR DESCRIPTION
## Summary
- structure core module into dedicated packages for chat, state, tools, permissions, roles, presets, settings, mcp, model and repositories
- update imports and references across plugin code to use the new package paths

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6893a2c13ec48320b9cb2d0d3dd9c8c8