### PR TITLE
Persist MCP server enabled state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ File permissions can also be adjusted by adding a `sona.json` file at the projec
 configurations including name, command, arguments, environment variables, transport, URL,
 working directory and request headers. Supported transports are `stdio` and `http` and each
 server runs in its own coroutine so failures are isolated. Tools exposed by these servers
-require the same user permission prompts as local tools.
+require the same user permission prompts as local tools. Server enablement is persisted so only
+servers enabled previously reconnect automatically on restart.
 `ChatFlow` depends only on the `Tools` interface and receives the decorator from `StateProvider`.
 
 Whenever you extend the logic make sure the flow of state remains unidirectional

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ not affect the plugin. Tools provided by MCP servers require the same user confi
 The tool window includes a **Servers** action listing all configured MCP servers. Each server is shown as a card
 with a coloured status indicator – grey for disabled, red when a connection fails, yellow while connecting and
 green once connected and exposing tools. Clicking a card toggles the server on or off. A refresh button above
-the list reloads `sona.json` and reconnects previously enabled servers.
+the list reloads `sona.json` and reconnects previously enabled servers. Server enablement is persisted so only
+servers that were on previously start automatically after restarting the IDE.
 
 ```json
 {

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpServersRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpServersRepository.kt
@@ -13,4 +13,6 @@ data class McpServerConfig(
 
 interface McpServersRepository {
     suspend fun list(): List<McpServerConfig>
+    suspend fun loadEnabled(): Set<String>
+    suspend fun saveEnabled(enabled: Set<String>)
 }

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -128,7 +128,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
             },
             externalTools = externalTools,
             filePermissionRepository = PluginFilePermissionsRepository(project),
-            mcpServersRepository = PluginMcpServersRepository(project),
+            mcpServersRepository = project.service<PluginMcpServersRepository>(),
             scope = scope,
             systemMessages = createSystemMessages(),
         )

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -66,6 +66,7 @@
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginRolesRepository"/>
         <applicationService serviceImplementation="io.qent.sona.repositories.PluginPresetsRepository"/>
         <applicationService serviceImplementation="io.qent.sona.services.ThemeService"/>
+        <projectService serviceImplementation="io.qent.sona.repositories.PluginMcpServersRepository"/>
 
         <applicationConfigurable
                 id="SonaChatSettings"


### PR DESCRIPTION
## Summary
- persist MCP server enablement state via repository methods and new IntelliJ service
- connect, toggle, and reload servers using stored enabled set
- document persisted server status in AGENTS and README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6893b69216688320b8b8027d3b28e670