### PR TITLE
feat: add anthropic caching settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@
     Code roles cannot be deleted.
 - LLM connection details are organised as presets via `PresetsRepository`. At least one preset must exist for the chat
   to work and they are managed from the Presets screen.
-- Plugin settings contain only the "Ignore HTTPS errors" flag which, when enabled, trusts all HTTPS certificates.
+- Plugin settings contain an "Ignore HTTPS errors" flag and an "Anthropic Settings"
+  section to cache system prompts and tool descriptions in requests.
 - Each chat tracks tools approved by the user so that previously allowed tools run without asking again.
 - A 🤘 button next to the send action can temporarily auto-approve all tool
   requests in the current chat. The setting resets when switching chats and is

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ The chat header shows token usage together with the estimated cost for the last
 message and for the entire conversation. It also displays how much of the
 model's context window is currently filled based on the active preset.
 
-The settings screen contains only a single option: **Ignore HTTPS errors**. Enable
-it to trust all HTTPS certificates when connecting to custom endpoints.
+The settings screen is split into two sections. **Plugin Settings** contains the
+original **Ignore HTTPS errors** option. Enable it to trust all HTTPS
+certificates when connecting to custom endpoints. The new **Anthropic Settings**
+section adds checkboxes to cache system prompts and tool descriptions when
+sending requests to Anthropic models.
 
 ## Model pricing
 

--- a/core/src/main/kotlin/io/qent/sona/core/settings/Settings.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/settings/Settings.kt
@@ -1,5 +1,7 @@
 package io.qent.sona.core.settings
 
 data class Settings(
-    val ignoreHttpsErrors: Boolean
+    val ignoreHttpsErrors: Boolean,
+    val cacheSystemPrompts: Boolean,
+    val cacheToolDescriptions: Boolean,
 )

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -89,6 +89,15 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
                         if (settingsRepository.state.ignoreHttpsErrors) {
                             builder.httpClientBuilder(ignoreHttpsClientBuilder())
                         }
+                        if (settingsRepository.state.cacheSystemPrompts) {
+                            builder.cacheSystemMessages(true)
+                        }
+                        if (settingsRepository.state.cacheToolDescriptions) {
+                            builder.cacheTools(true)
+                        }
+                        if (settingsRepository.state.cacheSystemPrompts || settingsRepository.state.cacheToolDescriptions) {
+                            builder.beta("prompt-caching-2024-07-31")
+                        }
                         builder.build()
                     }
 

--- a/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
@@ -14,6 +14,8 @@ class PluginSettingsRepository :
     PersistentStateComponent<PluginSettingsRepository.PluginSettingsState> {
     data class PluginSettingsState(
         var ignoreHttpsErrors: Boolean = false,
+        var cacheSystemPrompts: Boolean = false,
+        var cacheToolDescriptions: Boolean = false,
     )
 
     private var pluginSettingsState = PluginSettingsState()
@@ -26,5 +28,7 @@ class PluginSettingsRepository :
 
     override suspend fun load() = Settings(
         pluginSettingsState.ignoreHttpsErrors,
+        pluginSettingsState.cacheSystemPrompts,
+        pluginSettingsState.cacheToolDescriptions,
     )
 }

--- a/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
@@ -17,18 +17,40 @@ class PluginSettingsConfigurable : Configurable {
 
     private val repo = service<PluginSettingsRepository>()
     private var currentIgnoreHttpsErrors = repo.state.ignoreHttpsErrors
+    private var currentCacheSystemPrompts = repo.state.cacheSystemPrompts
+    private var currentCacheToolDescriptions = repo.state.cacheToolDescriptions
 
     override fun createComponent() = JewelComposePanel {
         val themeService = service<ThemeService>()
         val dark by themeService.isDark.collectAsState()
-        var checked by remember { mutableStateOf(currentIgnoreHttpsErrors) }
-        LaunchedEffect(checked) { currentIgnoreHttpsErrors = checked }
+        var ignoreHttps by remember { mutableStateOf(currentIgnoreHttpsErrors) }
+        var cacheSystemPrompts by remember { mutableStateOf(currentCacheSystemPrompts) }
+        var cacheToolDescriptions by remember { mutableStateOf(currentCacheToolDescriptions) }
+        LaunchedEffect(ignoreHttps) { currentIgnoreHttpsErrors = ignoreHttps }
+        LaunchedEffect(cacheSystemPrompts) { currentCacheSystemPrompts = cacheSystemPrompts }
+        LaunchedEffect(cacheToolDescriptions) { currentCacheToolDescriptions = cacheToolDescriptions }
         SonaTheme(dark = dark) {
             Column(modifier = Modifier.width(600.dp).padding(16.dp)) {
+                Text("Plugin Settings")
+                Spacer(Modifier.height(8.dp))
                 Row {
-                    Checkbox(checked = checked, onCheckedChange = { checked = it })
+                    Checkbox(checked = ignoreHttps, onCheckedChange = { ignoreHttps = it })
                     Spacer(Modifier.width(8.dp))
                     Text("Ignore HTTPS errors")
+                }
+                Spacer(Modifier.height(16.dp))
+                Text("Anthropic Settings")
+                Spacer(Modifier.height(8.dp))
+                Row {
+                    Checkbox(checked = cacheSystemPrompts, onCheckedChange = { cacheSystemPrompts = it })
+                    Spacer(Modifier.width(8.dp))
+                    Text("Cache system prompts")
+                }
+                Spacer(Modifier.height(8.dp))
+                Row {
+                    Checkbox(checked = cacheToolDescriptions, onCheckedChange = { cacheToolDescriptions = it })
+                    Spacer(Modifier.width(8.dp))
+                    Text("Cache tool descriptions")
                 }
             }
         }
@@ -36,11 +58,19 @@ class PluginSettingsConfigurable : Configurable {
 
     override fun isModified(): Boolean {
         val saved = repo.state
-        return currentIgnoreHttpsErrors != saved.ignoreHttpsErrors
+        return currentIgnoreHttpsErrors != saved.ignoreHttpsErrors ||
+            currentCacheSystemPrompts != saved.cacheSystemPrompts ||
+            currentCacheToolDescriptions != saved.cacheToolDescriptions
     }
 
     override fun apply() {
-        repo.loadState(PluginSettingsRepository.PluginSettingsState(currentIgnoreHttpsErrors))
+        repo.loadState(
+            PluginSettingsRepository.PluginSettingsState(
+                currentIgnoreHttpsErrors,
+                currentCacheSystemPrompts,
+                currentCacheToolDescriptions,
+            )
+        )
     }
 
     override fun getDisplayName(): String = "Sona"


### PR DESCRIPTION
## Summary
- split settings UI into Plugin Settings and Anthropic Settings sections
- allow caching system prompts and tool descriptions for Anthropic chat
- persist new settings and document updated behaviour

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689450f1079c83209ca550722fd7bf42