### PR TITLE
Add MCP config editor and server persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,12 +52,13 @@ permission manager that checks absolute paths against a whitelist (project root 
 and a blacklist of sensitive files before exposing file contents to the model.
 File permissions can also be adjusted by adding a `sona.json` file at the project root with
 `permissions.files.whitelist` and `blacklist` arrays of regex patterns.
-`sona.json` may additionally define an `mcpServers` array with Model Context Protocol server
-configurations including name, command, arguments, environment variables, transport, URL,
-working directory and request headers. Supported transports are `stdio` and `http` and each
-server runs in its own coroutine so failures are isolated. Tools exposed by these servers
-require the same user permission prompts as local tools. Server enablement is persisted so only
-servers enabled previously reconnect automatically on restart.
+`sona.json` may additionally define an `mcpServers` object keyed by server name with Model
+Context Protocol server configurations including `enabled`, `command`, `args`, environment
+variables, transport, URL, working directory and request headers. Supported transports are
+`stdio` and `http` and each server runs in its own coroutine so failures are isolated. Tools
+exposed by these servers require the same user permission prompts as local tools. Server
+enablement is stored in `sona.json` and only servers marked as enabled reconnect automatically
+on restart.
 `ChatFlow` depends only on the `Tools` interface and receives the decorator from `StateProvider`.
 
 Whenever you extend the logic make sure the flow of state remains unidirectional

--- a/README.md
+++ b/README.md
@@ -102,25 +102,27 @@ The available tools let the model read the focused file, read any file by absolu
 }
 ```
 
-The same configuration file can also include an `mcpServers` array specifying Model Context Protocol
-servers. Each entry supports `name`, `command`, `args`, `env`, `transport`, `url`, `cwd` and `headers` fields.
-When `command` is `npx`, Sona resolves the absolute path to the `npx` executable by checking typical
-installation locations for the current operating system before launching the server. Currently
-`transport` may be `stdio` or `http`. Every server runs in its own coroutine so a failure does
+The same configuration file can also include an `mcpServers` object keyed by server name specifying Model
+Context Protocol servers. Each entry supports `enabled`, `command`, `args`, `env`, `transport`, `url`, `cwd`
+and `headers` fields. When `command` is `npx`, Sona resolves the absolute path to the `npx` executable by
+checking typical installation locations for the current operating system before launching the server.
+Currently `transport` may be `stdio` or `http`. Every server runs in its own coroutine so a failure does
 not affect the plugin. Tools provided by MCP servers require the same user confirmation as local tools.
 
 The tool window includes a **Servers** action listing all configured MCP servers. Each server is shown as a card
 with a coloured status indicator – grey for disabled, red when a connection fails, yellow while connecting and
 green once connected and exposing tools. Clicking a card toggles the server on or off. A refresh button above
-the list reloads `sona.json` and reconnects previously enabled servers. Server enablement is persisted so only
-servers that were on previously start automatically after restarting the IDE.
+the list reloads `sona.json` and reconnects previously enabled servers. A pinned **Редактировать конфигурацию**
+button at the bottom opens `sona.json`, creating it with the current server configuration and file permission
+lists when missing. Server enablement is stored in `sona.json` so only servers marked as enabled start
+automatically after restarting the IDE.
 
 ```json
 {
-  "mcpServers": [
-    { "name": "calc", "command": "calc-mcp", "transport": "stdio" },
-    { "name": "weather", "url": "https://example.com/mcp", "transport": "http" }
-  ]
+  "mcpServers": {
+    "calc": { "enabled": true, "command": "calc-mcp", "transport": "stdio" },
+    "weather": { "enabled": false, "url": "https://example.com/mcp", "transport": "http" }
+  }
 }
 ```
 

--- a/core/src/main/kotlin/io/qent/sona/core/state/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/State.kt
@@ -106,6 +106,7 @@ sealed class State {
         val servers: StateFlow<List<McpServerStatus>>,
         val onToggleServer: (String) -> Unit,
         val onReload: () -> Unit,
+        val onEditConfig: () -> Unit,
         override val onNewChat: () -> Unit,
         override val onOpenHistory: () -> Unit,
         override val onOpenRoles: () -> Unit,

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
@@ -41,6 +41,7 @@ class StateProvider(
     externalTools: ExternalTools,
     filePermissionRepository: FilePermissionsRepository,
     mcpServersRepository: McpServersRepository,
+    private val editConfig: () -> Unit,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     private val systemMessages: List<SystemMessage> = emptyList(),
 ) {
@@ -288,6 +289,7 @@ class StateProvider(
         servers = mcpManager.servers,
         onToggleServer = { name -> mcpManager.toggle(name) },
         onReload = { scope.launch { mcpManager.reload() } },
+        onEditConfig = editConfig,
         onNewChat = { scope.launch { newChat() } },
         onOpenHistory = { scope.launch { showHistory() } },
         onOpenRoles = { scope.launch { showRoles() } },

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -138,6 +138,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
             externalTools = externalTools,
             filePermissionRepository = PluginFilePermissionsRepository(project),
             mcpServersRepository = project.service<PluginMcpServersRepository>(),
+            editConfig = { project.service<PluginMcpServersRepository>().openConfig() },
             scope = scope,
             systemMessages = createSystemMessages(),
         )

--- a/src/main/kotlin/io/qent/sona/config/SonaConfig.kt
+++ b/src/main/kotlin/io/qent/sona/config/SonaConfig.kt
@@ -1,11 +1,12 @@
 package io.qent.sona.config
 
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import java.io.File
 
 class SonaConfig {
     var permissions: Permissions? = null
-    var mcpServers: List<McpServer>? = null
+    var mcpServers: MutableMap<String, McpServer>? = null
 
     class Permissions {
         var files: Files? = null
@@ -17,11 +18,11 @@ class SonaConfig {
     }
 
     class McpServer {
-        var name: String? = null
+        var enabled: Boolean? = null
         var command: String? = null
         var args: List<String>? = null
         var env: Map<String, String>? = null
-        var transport: String = "stdio"
+        var transport: String? = "stdio"
         var url: String? = null
         var cwd: String? = null
         var headers: Map<String, String>? = null
@@ -33,6 +34,12 @@ class SonaConfig {
             return runCatching {
                 if (file.exists()) file.reader().use { Gson().fromJson(it, SonaConfig::class.java) } else null
             }.getOrNull()
+        }
+
+        fun save(root: String, config: SonaConfig) {
+            val file = File(root, "sona.json")
+            val gson: Gson = GsonBuilder().setPrettyPrinting().create()
+            file.writer().use { gson.toJson(config, it) }
         }
     }
 }

--- a/src/main/kotlin/io/qent/sona/ui/mcp/ServersPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/mcp/ServersPanel.kt
@@ -2,7 +2,15 @@ package io.qent.sona.ui.mcp
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -32,29 +40,31 @@ import java.net.URI
 fun ServersPanel(state: State.ServersState) {
     val servers by state.servers.collectAsState(emptyList())
     val listState = rememberLazyListState()
-    Column(
+    Box(
         Modifier
             .fillMaxSize()
             .background(SonaTheme.colors.Background)
             .padding(8.dp)
     ) {
-        Row(Modifier.fillMaxWidth()) {
-            Text(
-                "MCP Servers",
-                modifier = Modifier.padding(top = 8.dp, bottom = 12.dp),
-                style = SonaTheme.markdownTypography.h5
-            )
-            ActionButton(onClick = state.onReload, Modifier.padding(4.dp)) {
-                Text("\u27f3", Modifier.padding(4.dp), fontSize = 24.sp)
+        Column(Modifier.fillMaxSize()) {
+            Row(Modifier.fillMaxWidth()) {
+                Text(
+                    "MCP Servers",
+                    modifier = Modifier.padding(top = 8.dp, bottom = 12.dp),
+                    style = SonaTheme.markdownTypography.h5
+                )
+                ActionButton(onClick = state.onReload, Modifier.padding(4.dp)) {
+                    Text("\u27f3", Modifier.padding(4.dp), fontSize = 24.sp)
+                }
             }
-        }
-        LazyColumn(
-            state = listState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-        ) {
-            items(servers) { server ->
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentPadding = PaddingValues(bottom = 56.dp)
+            ) {
+                items(servers) { server ->
                 val expanded = remember { mutableStateOf(false) }
                 Column(
                     Modifier
@@ -141,11 +151,30 @@ fun ServersPanel(state: State.ServersState) {
                 }
             }
         }
+        }
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 8.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(color = SonaTheme.colors.UserBubble)
+                    .clickable { state.onEditConfig() }
+                    .padding(horizontal = 10.dp, vertical = 6.dp)
+            ) {
+                Text(
+                    "Редактировать конфигурацию",
+                    color = Color.White,
+                    fontSize = 12.sp
+                )
+            }
+        }
     }
 }
 
-fun McpServerStatus.jetbrainsMcpProxyUnavailable(
-
-) = name == "@jetbrains/mcp-proxy" && (status as? McpServerStatus.Status.FAILED)?.e?.toString()?.let { error ->
-    error.contains("NullPointerException") && error.contains("com.fasterxml.jackson.databind.JsonNode")
-}  ?: false
+fun McpServerStatus.jetbrainsMcpProxyUnavailable() =
+    name == "@jetbrains/mcp-proxy" && (status as? McpServerStatus.Status.FAILED)?.e?.toString()?.let { error ->
+        error.contains("NullPointerException") && error.contains("com.fasterxml.jackson.databind.JsonNode")
+    } ?: false


### PR DESCRIPTION
## Summary
- Pin an always-visible "Редактировать конфигурацию" button to the MCP servers panel
- Store MCP server enablement in `sona.json` and allow editing/creation from the UI
- Restructure `mcpServers` config to use server names as keys with `enabled` flags

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6894d0bba0008320b6cd1dedc0d36a7c