### PR TITLE
Load LLM providers from JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
     Code roles cannot be deleted.
 - LLM connection details are organised as presets via `PresetsRepository`. At least one preset must exist for the chat
   to work and they are managed from the Presets screen.
+- Supported LLM providers and models are defined in `core/src/main/resources/providers.json` so new options can be
+  added without modifying the code.
 - Plugin settings contain only the "Ignore HTTPS errors" flag which, when enabled, trusts all HTTPS certificates.
 - Each chat tracks tools approved by the user so that previously allowed tools run without asking again.
 - A 🤘 button next to the send action can temporarily auto-approve all tool

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ task..." prompt. Once messages are present, the placeholder becomes
 LLM credentials are stored as presets. Each preset defines the provider, model,
 API endpoint and token. Manage presets from the Presets screen opened via the
 tool window actions. At least one preset must exist for the chat to function.
+Supported providers and their models are listed in `core/src/main/resources/providers.json`
+so new options can be added without touching the code.
 
 The chat header shows token usage together with the estimated cost for the last
 message and for the entire conversation. It also displays how much of the
@@ -56,9 +58,9 @@ it to trust all HTTPS certificates when connecting to custom endpoints.
 
 ## Model pricing
 
-Token costs are embedded for each supported model so conversations can display
-their estimated price. The rates below are in USD per million tokens and are
-based on the official pricing pages.
+Token costs are loaded from `providers.json` so conversations can display their
+estimated price. The rates below are in USD per million tokens and are based on
+the official pricing pages.
 
 | Provider | Model | Input | Output | Source |
 | --- | --- | --- | --- | --- |

--- a/core/src/main/kotlin/io/qent/sona/core/presets/PresetsRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/presets/PresetsRepository.kt
@@ -1,5 +1,8 @@
 package io.qent.sona.core.presets
 
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
 /** Information about a specific LLM model. */
 data class LlmModel(
     val name: String,
@@ -10,111 +13,28 @@ data class LlmModel(
     val maxContextTokens: Int = 0,
 )
 
-enum class LlmProvider(val defaultEndpoint: String, val models: List<LlmModel>) {
-    Anthropic(
-        "https://api.anthropic.com/v1/",
-        listOf(
-            // Pricing: https://www.anthropic.com/pricing#api
-            LlmModel(
-                name = "claude-sonnet-4-20250514",
-                outputCostPerMTokens = 15.0,
-                inputCostPerMTokens = 3.0,
-                cacheCreationCostPerMTokens = 3.75,
-                cacheReadCostPerMTokens = 0.30,
-                maxContextTokens = 200_000,
-            ),
-            LlmModel(
-                name = "claude-3-7-sonnet-20250219",
-                outputCostPerMTokens = 15.0,
-                inputCostPerMTokens = 3.0,
-                cacheCreationCostPerMTokens = 3.75,
-                cacheReadCostPerMTokens = 0.30,
-                maxContextTokens = 200_000,
-            ),
-            LlmModel(
-                name = "claude-3-5-haiku-20241022",
-                outputCostPerMTokens = 4.0,
-                inputCostPerMTokens = 0.80,
-                cacheCreationCostPerMTokens = 1.0,
-                cacheReadCostPerMTokens = 0.08,
-                maxContextTokens = 200_000,
-            ),
-        ),
-    ),
-    OpenAI(
-        "https://api.openai.com/v1/",
-        listOf(
-            // Pricing: https://platform.openai.com/docs/pricing
-            LlmModel(
-                name = "o3",
-                outputCostPerMTokens = 8.0,
-                inputCostPerMTokens = 2.0,
-                cacheReadCostPerMTokens = 0.5,
-                maxContextTokens = 128_000,
-            ),
-            LlmModel(
-                name = "gpt-4.1",
-                outputCostPerMTokens = 8.0,
-                inputCostPerMTokens = 2.0,
-                cacheReadCostPerMTokens = 0.5,
-                maxContextTokens = 128_000,
-            ),
-            LlmModel(
-                name = "gpt-4.1-mini",
-                outputCostPerMTokens = 1.6,
-                inputCostPerMTokens = 0.4,
-                cacheReadCostPerMTokens = 0.1,
-                maxContextTokens = 128_000,
-            ),
-            LlmModel(
-                name = "gpt-4o",
-                outputCostPerMTokens = 10.0,
-                inputCostPerMTokens = 2.5,
-                cacheReadCostPerMTokens = 1.25,
-                maxContextTokens = 128_000,
-            ),
-        ),
-    ),
-    Deepseek(
-        "https://api.deepseek.com/v1/",
-        listOf(
-            // Pricing: https://api-docs.deepseek.com/quick_start/pricing
-            LlmModel(
-                name = "deepseek-chat",
-                outputCostPerMTokens = 1.10,
-                inputCostPerMTokens = 0.27,
-                cacheReadCostPerMTokens = 0.07,
-                maxContextTokens = 64_000,
-            ),
-            LlmModel(
-                name = "deepseek-reasoner",
-                outputCostPerMTokens = 2.19,
-                inputCostPerMTokens = 0.55,
-                cacheReadCostPerMTokens = 0.14,
-                maxContextTokens = 64_000,
-            ),
-        ),
-    ),
-    Gemini(
-        "https://generativelanguage.googleapis.com/v1beta/",
-        listOf(
-            // Pricing: https://ai.google.dev/gemini-api/docs/pricing
-            LlmModel(
-                name = "gemini-2.5-pro",
-                outputCostPerMTokens = 10.0,
-                inputCostPerMTokens = 1.25,
-                cacheCreationCostPerMTokens = 0.31,
-                maxContextTokens = 128_000,
-            ),
-            LlmModel(
-                name = "gemini-2.5-flash",
-                outputCostPerMTokens = 2.5,
-                inputCostPerMTokens = 0.30,
-                cacheCreationCostPerMTokens = 0.075,
-                maxContextTokens = 128_000,
-            ),
-        ),
-    );
+/** Information about a provider and its models. */
+data class LlmProvider(
+    val name: String,
+    val defaultEndpoint: String,
+    val models: List<LlmModel>,
+)
+
+/** Loads provider information from a JSON resource for easy updates. */
+object LlmProviders {
+    private val gson = Gson()
+    private val type = object : TypeToken<List<LlmProvider>>() {}.type
+
+    val entries: List<LlmProvider> by lazy {
+        LlmProviders::class.java.getResourceAsStream("/providers.json")!!.use { stream ->
+            gson.fromJson(stream.reader(), type)
+        }
+    }
+
+    fun find(name: String): LlmProvider? = entries.find { it.name == name }
+
+    val default: LlmProvider
+        get() = entries.first()
 }
 
 data class Preset(

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
@@ -27,6 +27,7 @@ import io.qent.sona.core.roles.RolesRepository
 import io.qent.sona.core.roles.DefaultRoles
 import io.qent.sona.core.roles.Role
 import io.qent.sona.core.presets.LlmProvider
+import io.qent.sona.core.presets.LlmProviders
 import io.qent.sona.core.tools.DefaultInternalTools
 import io.qent.sona.core.tools.ExternalTools
 import io.qent.sona.core.tools.Tools
@@ -257,11 +258,12 @@ class StateProvider(
     private fun createPresetsState(): State.PresetsState {
         val emptyPresets = presets.presets.isEmpty()
         val preset = if (creatingPreset || emptyPresets) {
+            val defaultProvider = LlmProviders.default
             Preset(
-                name = "Sonnet 4.0",
-                provider = LlmProvider.Anthropic,
-                apiEndpoint = LlmProvider.Anthropic.defaultEndpoint,
-                model = LlmProvider.Anthropic.models.first().name,
+                name = defaultProvider.models.first().name,
+                provider = defaultProvider,
+                apiEndpoint = defaultProvider.defaultEndpoint,
+                model = defaultProvider.models.first().name,
                 apiKey = "",
             )
         } else {

--- a/core/src/main/resources/providers.json
+++ b/core/src/main/resources/providers.json
@@ -1,0 +1,106 @@
+[
+  {
+    "name": "Anthropic",
+    "defaultEndpoint": "https://api.anthropic.com/v1/",
+    "models": [
+      {
+        "name": "claude-sonnet-4-20250514",
+        "outputCostPerMTokens": 15.0,
+        "inputCostPerMTokens": 3.0,
+        "cacheCreationCostPerMTokens": 3.75,
+        "cacheReadCostPerMTokens": 0.30,
+        "maxContextTokens": 200000
+      },
+      {
+        "name": "claude-3-7-sonnet-20250219",
+        "outputCostPerMTokens": 15.0,
+        "inputCostPerMTokens": 3.0,
+        "cacheCreationCostPerMTokens": 3.75,
+        "cacheReadCostPerMTokens": 0.30,
+        "maxContextTokens": 200000
+      },
+      {
+        "name": "claude-3-5-haiku-20241022",
+        "outputCostPerMTokens": 4.0,
+        "inputCostPerMTokens": 0.80,
+        "cacheCreationCostPerMTokens": 1.0,
+        "cacheReadCostPerMTokens": 0.08,
+        "maxContextTokens": 200000
+      }
+    ]
+  },
+  {
+    "name": "OpenAI",
+    "defaultEndpoint": "https://api.openai.com/v1/",
+    "models": [
+      {
+        "name": "o3",
+        "outputCostPerMTokens": 8.0,
+        "inputCostPerMTokens": 2.0,
+        "cacheReadCostPerMTokens": 0.5,
+        "maxContextTokens": 128000
+      },
+      {
+        "name": "gpt-4.1",
+        "outputCostPerMTokens": 8.0,
+        "inputCostPerMTokens": 2.0,
+        "cacheReadCostPerMTokens": 0.5,
+        "maxContextTokens": 128000
+      },
+      {
+        "name": "gpt-4.1-mini",
+        "outputCostPerMTokens": 1.6,
+        "inputCostPerMTokens": 0.4,
+        "cacheReadCostPerMTokens": 0.1,
+        "maxContextTokens": 128000
+      },
+      {
+        "name": "gpt-4o",
+        "outputCostPerMTokens": 10.0,
+        "inputCostPerMTokens": 2.5,
+        "cacheReadCostPerMTokens": 1.25,
+        "maxContextTokens": 128000
+      }
+    ]
+  },
+  {
+    "name": "Deepseek",
+    "defaultEndpoint": "https://api.deepseek.com/v1/",
+    "models": [
+      {
+        "name": "deepseek-chat",
+        "outputCostPerMTokens": 1.10,
+        "inputCostPerMTokens": 0.27,
+        "cacheReadCostPerMTokens": 0.07,
+        "maxContextTokens": 64000
+      },
+      {
+        "name": "deepseek-reasoner",
+        "outputCostPerMTokens": 2.19,
+        "inputCostPerMTokens": 0.55,
+        "cacheReadCostPerMTokens": 0.14,
+        "maxContextTokens": 64000
+      }
+    ]
+  },
+  {
+    "name": "Gemini",
+    "defaultEndpoint": "https://generativelanguage.googleapis.com/v1beta/",
+    "models": [
+      {
+        "name": "gemini-2.5-pro",
+        "outputCostPerMTokens": 10.0,
+        "inputCostPerMTokens": 1.25,
+        "cacheCreationCostPerMTokens": 0.31,
+        "maxContextTokens": 128000
+      },
+      {
+        "name": "gemini-2.5-flash",
+        "outputCostPerMTokens": 2.5,
+        "inputCostPerMTokens": 0.30,
+        "cacheCreationCostPerMTokens": 0.075,
+        "maxContextTokens": 128000
+      }
+    ]
+  }
+]

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -11,7 +11,6 @@ import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
 import io.qent.sona.core.model.TokenUsageInfo
-import io.qent.sona.core.presets.LlmProvider
 import io.qent.sona.core.presets.Presets
 import io.qent.sona.core.state.State
 import io.qent.sona.core.state.StateProvider
@@ -80,8 +79,8 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
             chatRepository,
             rolesRepository,
             modelFactory = { preset ->
-                when (preset.provider) {
-                    LlmProvider.Anthropic -> {
+                when (preset.provider.name) {
+                    "Anthropic" -> {
                         val builder = AnthropicStreamingChatModel.builder()
                             .apiKey(preset.apiKey)
                             .baseUrl(preset.apiEndpoint)
@@ -92,7 +91,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
                         builder.build()
                     }
 
-                    LlmProvider.OpenAI -> {
+                    "OpenAI" -> {
                         val builder = OpenAiStreamingChatModel.builder()
                             .apiKey(preset.apiKey)
                             .baseUrl(preset.apiEndpoint)
@@ -103,7 +102,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
                         builder.build()
                     }
 
-                    LlmProvider.Deepseek -> {
+                    "Deepseek" -> {
                         val builder = OpenAiStreamingChatModel.builder()
                             .apiKey(preset.apiKey)
                             .baseUrl(preset.apiEndpoint)
@@ -114,7 +113,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
                         builder.build()
                     }
 
-                    LlmProvider.Gemini -> {
+                    "Gemini" -> {
                         val builder = GoogleAiGeminiStreamingChatModel.builder()
                             .apiKey(preset.apiKey)
                             .baseUrl(preset.apiEndpoint)
@@ -124,6 +123,7 @@ class PluginStateFlow(private val project: Project) : Flow<State> {
                         }
                         builder.build()
                     }
+                    else -> throw IllegalArgumentException("Unknown provider ${preset.provider.name}")
                 }
             },
             externalTools = externalTools,

--- a/src/main/kotlin/io/qent/sona/repositories/PluginPresetsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginPresetsRepository.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import io.qent.sona.core.presets.LlmProvider
+import io.qent.sona.core.presets.LlmProviders
 import io.qent.sona.core.presets.Preset
 import io.qent.sona.core.presets.Presets
 import io.qent.sona.core.presets.PresetsRepository
@@ -16,9 +17,9 @@ class PluginPresetsRepository : PresetsRepository,
 
     data class StoredPreset(
         var name: String = "",
-        var provider: String = LlmProvider.Anthropic.name,
-        var apiEndpoint: String = LlmProvider.Anthropic.defaultEndpoint,
-        var model: String = LlmProvider.Anthropic.models.first().name,
+        var provider: String = LlmProviders.default.name,
+        var apiEndpoint: String = LlmProviders.default.defaultEndpoint,
+        var model: String = LlmProviders.default.models.first().name,
         var apiKey: String = "",
     )
 
@@ -37,7 +38,7 @@ class PluginPresetsRepository : PresetsRepository,
 
     override suspend fun load(): Presets {
         val presets = state.presets.map { stored ->
-            val provider = runCatching { LlmProvider.valueOf(stored.provider) }.getOrDefault(LlmProvider.Anthropic)
+            val provider = LlmProviders.find(stored.provider) ?: LlmProviders.default
             Preset(
                 stored.name,
                 provider,

--- a/src/main/kotlin/io/qent/sona/ui/presets/PresetsPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/presets/PresetsPanel.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import io.qent.sona.core.presets.LlmProvider
+import io.qent.sona.core.presets.LlmProviders
 import io.qent.sona.core.presets.Preset
 import io.qent.sona.core.state.State
 import io.qent.sona.ui.DropdownSelector
@@ -176,10 +177,10 @@ private fun PresetForm(
         Text("Provider")
         Spacer(Modifier.height(2.dp))
         DropdownSelector(
-            items = LlmProvider.entries.map { it.name },
-            selectedIndex = LlmProvider.entries.indexOf(provider),
+            items = LlmProviders.entries.map { it.name },
+            selectedIndex = LlmProviders.entries.indexOfFirst { it.name == provider.name },
             expandUpwards = false,
-            onSelect = { idx -> onProviderChange(LlmProvider.entries[idx]) },
+            onSelect = { idx -> onProviderChange(LlmProviders.entries[idx]) },
             modifier = Modifier.fillMaxWidth(),
             backgroundColor = SonaTheme.colors.Background,
             buttonModifier = Modifier.fillMaxWidth()


### PR DESCRIPTION
## Summary
- load LLM providers and models from `providers.json`
- derive presets and UI selections from the JSON-defined providers
- document where provider data resides

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689478b8133083209009a05752baf263