### PR TITLE
Refactor state handling into interactors and factory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,9 @@ IDE theme changes.
 
 ## Current structure
 
-- **core module** – contains `ChatFlow` and `StateProvider`. `ChatFlow` is a
+- **core module** – contains `ChatFlow`, a thin `StateProvider` facade, `StateFactory` and domain interactors (`ChatStateInteractor`, `RolesStateInteractor`, `PresetsStateInteractor`, `ServersStateInteractor`). `ChatFlow` is a
   `MutableStateFlow` based `Flow` that manages the conversation with the model
-  and keeps track of token usage. `StateProvider` maps that flow to a higher
-  level `State` used by the UI.
+  and keeps track of token usage while the interactors handle domain logic.
 - **Plugin module** – provides IntelliJ implementations of the repositories,
   the Compose UI and `PluginStateFlow`, a project service exposing
   `StateFlow<State>` from `StateProvider`.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,6 +15,7 @@ repositories {
 
 dependencies {
     implementation(libs.gson)
+    testImplementation(libs.junit)
     implementation(libs.langchain4j.core)
     implementation(libs.langchain4j.kotlin)
     implementation(libs.langchain4j.anthropic)

--- a/core/src/main/kotlin/io/qent/sona/core/state/ChatStateInteractor.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/ChatStateInteractor.kt
@@ -1,0 +1,52 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.chat.Chat
+import io.qent.sona.core.chat.ChatRepository
+import io.qent.sona.core.chat.ChatSummary
+import kotlinx.coroutines.flow.Flow
+
+interface ChatSession : Flow<Chat> {
+    suspend fun loadChat(id: String)
+    suspend fun send(text: String)
+    fun stop()
+    suspend fun deleteFrom(idx: Int)
+    fun toggleAutoApproveTools()
+    suspend fun resolveToolPermission(allow: Boolean, always: Boolean)
+}
+
+class ChatStateInteractor(
+    private val chatFlow: ChatSession,
+    private val chatRepository: ChatRepository,
+) {
+    val chat: Flow<Chat> = chatFlow
+
+    suspend fun newChat() {
+        val lastChat = chatRepository.listChats().firstOrNull()?.id ?: run {
+            chatFlow.loadChat(chatRepository.createChat())
+            return
+        }
+        if (chatRepository.loadMessages(lastChat).isEmpty()) {
+            chatFlow.loadChat(lastChat)
+        } else {
+            chatFlow.loadChat(chatRepository.createChat())
+        }
+    }
+
+    suspend fun openChat(id: String) = chatFlow.loadChat(id)
+
+    suspend fun listChats(): List<ChatSummary> = chatRepository.listChats()
+
+    suspend fun deleteChat(id: String) = chatRepository.deleteChat(id)
+
+    suspend fun send(text: String) = chatFlow.send(text)
+
+    fun stop() = chatFlow.stop()
+
+    suspend fun deleteFrom(idx: Int) = chatFlow.deleteFrom(idx)
+
+    fun toggleAutoApproveTools() = chatFlow.toggleAutoApproveTools()
+
+    suspend fun resolveToolPermission(allow: Boolean, always: Boolean) =
+        chatFlow.resolveToolPermission(allow, always)
+}
+

--- a/core/src/main/kotlin/io/qent/sona/core/state/PresetsStateInteractor.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/PresetsStateInteractor.kt
@@ -1,0 +1,55 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.presets.Preset
+import io.qent.sona.core.presets.Presets
+import io.qent.sona.core.presets.PresetsRepository
+
+class PresetsStateInteractor(private val repository: PresetsRepository) {
+    var presets: Presets = Presets(0, emptyList())
+        private set
+    var creatingPreset: Boolean = false
+        private set
+
+    suspend fun load(): Presets {
+        presets = repository.load()
+        return presets
+    }
+
+    suspend fun selectPreset(idx: Int) {
+        presets = presets.copy(active = idx)
+        repository.save(presets)
+    }
+
+    fun startCreatePreset() {
+        creatingPreset = true
+    }
+
+    fun finishCreatePreset() {
+        creatingPreset = false
+    }
+
+    suspend fun addPreset(preset: Preset) {
+        presets = Presets(active = presets.presets.size, presets = presets.presets + preset)
+        creatingPreset = false
+        repository.save(presets)
+    }
+
+    suspend fun deletePreset() {
+        if (presets.presets.isEmpty()) return
+        val list = presets.presets.toMutableList()
+        list.removeAt(presets.active)
+        val newActive = presets.active.coerceAtMost(list.lastIndex).coerceAtLeast(0)
+        presets = Presets(newActive, list)
+        repository.save(presets)
+    }
+
+    suspend fun savePreset(preset: Preset) {
+        val list = presets.presets.toMutableList()
+        if (list.isNotEmpty()) {
+            list[presets.active] = preset
+            presets = presets.copy(presets = list)
+            repository.save(presets)
+        }
+    }
+}
+

--- a/core/src/main/kotlin/io/qent/sona/core/state/RolesStateInteractor.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/RolesStateInteractor.kt
@@ -1,0 +1,55 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.roles.Role
+import io.qent.sona.core.roles.Roles
+import io.qent.sona.core.roles.RolesRepository
+import io.qent.sona.core.roles.DefaultRoles
+
+class RolesStateInteractor(private val repository: RolesRepository) {
+    var roles: Roles = Roles(0, emptyList())
+        private set
+    var creatingRole: Boolean = false
+        private set
+
+    suspend fun load(): Roles {
+        roles = repository.load()
+        return roles
+    }
+
+    suspend fun selectRole(idx: Int) {
+        roles = roles.copy(active = idx)
+        repository.save(roles)
+    }
+
+    suspend fun saveRole(text: String) {
+        val list = roles.roles.toMutableList()
+        list[roles.active] = list[roles.active].copy(text = text)
+        roles = roles.copy(roles = list)
+        repository.save(roles)
+    }
+
+    fun startCreateRole() {
+        creatingRole = true
+    }
+
+    fun finishCreateRole() {
+        creatingRole = false
+    }
+
+    suspend fun addRole(name: String, text: String) {
+        roles = Roles(active = roles.roles.size, roles = roles.roles + Role(name, text))
+        creatingRole = false
+        repository.save(roles)
+    }
+
+    suspend fun deleteRole() {
+        val currentName = roles.roles[roles.active].name
+        if (currentName in DefaultRoles.NAMES) return
+        val list = roles.roles.toMutableList()
+        list.removeAt(roles.active)
+        val newActive = roles.active.coerceAtMost(list.lastIndex)
+        roles = Roles(active = newActive, roles = list)
+        repository.save(roles)
+    }
+}
+

--- a/core/src/main/kotlin/io/qent/sona/core/state/ServersStateInteractor.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/ServersStateInteractor.kt
@@ -1,0 +1,22 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.mcp.McpServerStatus
+import kotlinx.coroutines.flow.StateFlow
+
+interface ServersController {
+    val servers: StateFlow<List<McpServerStatus>>
+    fun toggle(name: String)
+    suspend fun reload()
+    fun stop()
+}
+
+class ServersStateInteractor(private val controller: ServersController) {
+    val servers: StateFlow<List<McpServerStatus>> = controller.servers
+
+    fun toggle(name: String) = controller.toggle(name)
+
+    suspend fun reload() = controller.reload()
+
+    fun stop() = controller.stop()
+}
+

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateFactory.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateFactory.kt
@@ -1,0 +1,172 @@
+package io.qent.sona.core.state
+
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.ToolExecutionResultMessage
+import dev.langchain4j.data.message.UserMessage
+import io.qent.sona.core.chat.Chat
+import io.qent.sona.core.chat.ChatRepositoryMessage
+import io.qent.sona.core.chat.ChatSummary
+import io.qent.sona.core.model.TokenUsageInfo
+import io.qent.sona.core.presets.Preset
+import io.qent.sona.core.presets.Presets
+import io.qent.sona.core.roles.Roles
+import io.qent.sona.core.mcp.McpServerStatus
+import kotlinx.coroutines.flow.StateFlow
+
+class StateFactory {
+    fun createChatState(
+        chat: Chat,
+        roles: Roles,
+        presets: Presets,
+        onSelectRole: (Int) -> Unit,
+        onSelectPreset: (Int) -> Unit,
+        onSendMessage: (String) -> Unit,
+        onStop: () -> Unit,
+        onDeleteFrom: (Int) -> Unit,
+        onToggleAutoApprove: () -> Unit,
+        onAllowTool: () -> Unit,
+        onAlwaysAllowTool: () -> Unit,
+        onDenyTool: () -> Unit,
+        onNewChat: () -> Unit,
+        onOpenHistory: () -> Unit,
+        onOpenRoles: () -> Unit,
+        onOpenPresets: () -> Unit,
+        onOpenServers: () -> Unit,
+    ): State.ChatState {
+        val lastAi = chat.messages.lastOrNull { it.message is AiMessage }
+        val lastUsage = lastAi?.tokenUsage ?: TokenUsageInfo()
+        return State.ChatState(
+            messages = chat.messages.mapNotNull { it.toUiMessage() },
+            totalTokenUsage = chat.tokenUsage,
+            lastTokenUsage = lastUsage,
+            isSending = chat.requestInProgress,
+            roles = roles.roles.map { it.name },
+            activeRole = roles.active,
+            onSelectRole = onSelectRole,
+            presets = presets,
+            onSelectPreset = onSelectPreset,
+            onSendMessage = onSendMessage,
+            onStop = onStop,
+            onDeleteFrom = onDeleteFrom,
+            toolRequest = chat.toolRequest != null,
+            autoApproveTools = chat.autoApproveTools,
+            onToggleAutoApprove = onToggleAutoApprove,
+            onAllowTool = onAllowTool,
+            onAlwaysAllowTool = onAlwaysAllowTool,
+            onDenyTool = onDenyTool,
+            onNewChat = onNewChat,
+            onOpenHistory = onOpenHistory,
+            onOpenRoles = onOpenRoles,
+            onOpenPresets = onOpenPresets,
+            onOpenServers = onOpenServers,
+        )
+    }
+
+    fun createChatListState(
+        chats: List<ChatSummary>,
+        onOpenChat: (String) -> Unit,
+        onDeleteChat: (String) -> Unit,
+        onNewChat: () -> Unit,
+        onOpenRoles: () -> Unit,
+        onOpenPresets: () -> Unit,
+        onOpenServers: () -> Unit,
+    ) = State.ChatListState(
+        chats = chats.filter { it.messages != 0 }.map { it.toUi() },
+        onOpenChat = onOpenChat,
+        onDeleteChat = onDeleteChat,
+        onNewChat = onNewChat,
+        onOpenRoles = onOpenRoles,
+        onOpenPresets = onOpenPresets,
+        onOpenServers = onOpenServers,
+    )
+
+    fun createRolesState(
+        roles: Roles,
+        creatingRole: Boolean,
+        text: String,
+        onSelectRole: (Int) -> Unit,
+        onStartCreateRole: () -> Unit,
+        onAddRole: (String, String) -> Unit,
+        onDeleteRole: () -> Unit,
+        onSave: (String) -> Unit,
+        onNewChat: () -> Unit,
+        onOpenHistory: () -> Unit,
+        onOpenPresets: () -> Unit,
+        onOpenServers: () -> Unit,
+    ) = State.RolesState(
+        roles = roles.roles.map { it.name },
+        currentIndex = roles.active,
+        creating = creatingRole,
+        text = text,
+        onSelectRole = onSelectRole,
+        onStartCreateRole = onStartCreateRole,
+        onAddRole = onAddRole,
+        onDeleteRole = onDeleteRole,
+        onSave = onSave,
+        onNewChat = onNewChat,
+        onOpenHistory = onOpenHistory,
+        onOpenRoles = {},
+        onOpenPresets = onOpenPresets,
+        onOpenServers = onOpenServers,
+    )
+
+    fun createPresetsState(
+        presets: Presets,
+        creatingPreset: Boolean,
+        preset: Preset,
+        onSelectPreset: (Int) -> Unit,
+        onStartCreatePreset: () -> Unit,
+        onAddPreset: (Preset) -> Unit,
+        onDeletePreset: () -> Unit,
+        onSave: (Preset) -> Unit,
+        onNewChat: () -> Unit,
+        onOpenHistory: () -> Unit,
+        onOpenRoles: () -> Unit,
+        onOpenServers: () -> Unit,
+    ) = State.PresetsState(
+        presets = presets.presets.map { it.name },
+        currentIndex = presets.active,
+        creating = creatingPreset,
+        preset = preset,
+        onSelectPreset = onSelectPreset,
+        onStartCreatePreset = onStartCreatePreset,
+        onAddPreset = onAddPreset,
+        onDeletePreset = onDeletePreset,
+        onSave = onSave,
+        onNewChat = onNewChat,
+        onOpenHistory = onOpenHistory,
+        onOpenRoles = onOpenRoles,
+        onOpenServers = onOpenServers,
+    )
+
+    fun createServersState(
+        servers: StateFlow<List<McpServerStatus>>,
+        onToggleServer: (String) -> Unit,
+        onReload: () -> Unit,
+        onEditConfig: () -> Unit,
+        onNewChat: () -> Unit,
+        onOpenHistory: () -> Unit,
+        onOpenRoles: () -> Unit,
+        onOpenPresets: () -> Unit,
+    ) = State.ServersState(
+        servers = servers,
+        onToggleServer = onToggleServer,
+        onReload = onReload,
+        onEditConfig = onEditConfig,
+        onNewChat = onNewChat,
+        onOpenHistory = onOpenHistory,
+        onOpenRoles = onOpenRoles,
+        onOpenPresets = onOpenPresets,
+    )
+}
+
+private fun ChatRepositoryMessage.toUiMessage(): UiMessage? = when (val m = message) {
+    is AiMessage -> UiMessage.Ai(m.text().orEmpty(), m.toolExecutionRequests())
+    is UserMessage -> UiMessage.User(m.singleText().trim())
+    is ToolExecutionResultMessage -> UiMessage.Tool(m.text())
+    else -> null
+}
+
+private fun ChatSummary.toUi(): UiChatSummary =
+    UiChatSummary(id, firstMessage, messages, createdAt)
+

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
@@ -1,22 +1,12 @@
 package io.qent.sona.core.state
 
 import dev.langchain4j.data.message.SystemMessage
-import dev.langchain4j.data.message.AiMessage
-import dev.langchain4j.data.message.UserMessage
-import dev.langchain4j.data.message.ToolExecutionResultMessage
 import dev.langchain4j.model.chat.StreamingChatModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
 import io.qent.sona.core.chat.Chat
 import io.qent.sona.core.chat.ChatFlow
 import io.qent.sona.core.chat.ChatRepository
-import io.qent.sona.core.chat.ChatRepositoryMessage
-import io.qent.sona.core.chat.ChatSummary
 import io.qent.sona.core.mcp.McpConnectionManager
 import io.qent.sona.core.mcp.McpServersRepository
-import io.qent.sona.core.model.TokenUsageInfo
 import io.qent.sona.core.permissions.FilePermissionManager
 import io.qent.sona.core.permissions.FilePermissionsRepository
 import io.qent.sona.core.presets.Preset
@@ -25,245 +15,159 @@ import io.qent.sona.core.presets.PresetsRepository
 import io.qent.sona.core.roles.Roles
 import io.qent.sona.core.roles.RolesRepository
 import io.qent.sona.core.roles.DefaultRoles
-import io.qent.sona.core.roles.Role
-import io.qent.sona.core.presets.LlmProvider
-import io.qent.sona.core.presets.LlmProviders
 import io.qent.sona.core.tools.DefaultInternalTools
 import io.qent.sona.core.tools.ExternalTools
 import io.qent.sona.core.tools.Tools
 import io.qent.sona.core.tools.ToolsInfoDecorator
-
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 
 class StateProvider(
-    private val presetsRepository: PresetsRepository,
-    private val chatRepository: ChatRepository,
-    private val rolesRepository: RolesRepository,
+    presetsRepository: PresetsRepository,
+    chatRepository: ChatRepository,
+    rolesRepository: RolesRepository,
     modelFactory: (Preset) -> StreamingChatModel,
     externalTools: ExternalTools,
     filePermissionRepository: FilePermissionsRepository,
     mcpServersRepository: McpServersRepository,
     private val editConfig: () -> Unit,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
-    private val systemMessages: List<SystemMessage> = emptyList(),
+    systemMessages: List<SystemMessage> = emptyList(),
 ) {
-
     private val filePermissionManager = FilePermissionManager(filePermissionRepository)
-    private val internalTools = DefaultInternalTools(scope, ::selectRole)
+    private val internalTools = DefaultInternalTools(scope) { role -> scope.launch { rolesInteractor.selectRole(role.ordinal) } }
     private val tools: Tools = ToolsInfoDecorator(internalTools, externalTools, filePermissionManager)
     private val mcpManager = McpConnectionManager(mcpServersRepository, scope)
     private val chatFlow = ChatFlow(presetsRepository, rolesRepository, chatRepository, modelFactory, tools, scope, systemMessages, mcpManager)
 
-    private val _state = MutableSharedFlow<State>(replay = 1)
+    private val chatInteractor = ChatStateInteractor(object : ChatSession, Flow<Chat> by chatFlow {
+        override suspend fun loadChat(id: String) = chatFlow.loadChat(id)
+        override suspend fun send(text: String) = chatFlow.send(text)
+        override fun stop() = chatFlow.stop()
+        override suspend fun deleteFrom(idx: Int) = chatFlow.deleteFrom(idx)
+        override fun toggleAutoApproveTools() = chatFlow.toggleAutoApproveTools()
+        override suspend fun resolveToolPermission(allow: Boolean, always: Boolean) = chatFlow.resolveToolPermission(allow, always)
+    }, chatRepository)
+    private val rolesInteractor = RolesStateInteractor(rolesRepository)
+    private val presetsInteractor = PresetsStateInteractor(presetsRepository)
+    private val serversInteractor = ServersStateInteractor(object : ServersController {
+        override val servers = mcpManager.servers
+        override fun toggle(name: String) = mcpManager.toggle(name)
+        override suspend fun reload() = mcpManager.reload()
+        override fun stop() = mcpManager.stop()
+    })
+    private val factory = StateFactory()
 
+    private val _state = MutableSharedFlow<State>(replay = 1)
     val state: Flow<State> = _state
 
-    private var roles: Roles = Roles(0, emptyList())
-    private var creatingRole = false
-    private var presets: Presets = Presets(0, emptyList())
-    private var creatingPreset = false
-    private var currentChat: Chat = Chat("", TokenUsageInfo())
-
     init {
-        chatFlow.onEach { chat ->
-            currentChat = chat
-            _state.emit(createChatState(chat))
-        }.launchIn(scope)
-
+        chatInteractor.chat.onEach { chat -> emitChatState(chat) }.launchIn(scope)
         scope.launch {
-            roles = rolesRepository.load()
-            presets = presetsRepository.load()
-            val lastChatId = chatRepository.listChats().firstOrNull()?.id
-            if (presets.presets.isEmpty()) {
-                creatingPreset = true
-                _state.emit(createPresetsState())
-            } else if (lastChatId == null) {
-                newChat()
-            } else {
-                openChat(lastChatId)
+            rolesInteractor.load()
+            presetsInteractor.load()
+            val lastChatId = chatInteractor.listChats().firstOrNull()?.id
+            when {
+                presetsInteractor.presets.presets.isEmpty() -> {
+                    presetsInteractor.startCreatePreset()
+                    emitPresetsState()
+                }
+                lastChatId == null -> chatInteractor.newChat()
+                else -> chatInteractor.openChat(lastChatId)
             }
         }
     }
 
     fun dispose() {
-        mcpManager.stop()
+        serversInteractor.stop()
     }
 
-    private fun createChatState(chat: Chat): State.ChatState {
-        val lastAi = chat.messages.lastOrNull { it.message is AiMessage }
-        val lastUsage = lastAi?.tokenUsage ?: TokenUsageInfo()
-        return State.ChatState(
-            messages = chat.messages.mapNotNull { it.toUiMessage() },
-            totalTokenUsage = chat.tokenUsage,
-            lastTokenUsage = lastUsage,
-            isSending = chat.requestInProgress,
-            roles = roles.roles.map { it.name },
-            activeRole = roles.active,
-            onSelectRole = { idx -> scope.launch {
-                selectRole(idx)
-                _state.emit(createChatState(chat))
-            } },
+    private suspend fun emitChatState(chat: Chat) {
+        val roles: Roles = rolesInteractor.roles
+        val presets: Presets = presetsInteractor.presets
+        val state = factory.createChatState(
+            chat = chat,
+            roles = roles,
             presets = presets,
-            onSelectPreset = { idx -> scope.launch { selectChatPreset(idx) } },
-            onSendMessage = { text -> scope.launch { send(text) } },
-            onStop = { scope.launch { stop() } },
-            onDeleteFrom = { idx -> scope.launch { deleteFrom(idx) } },
-            toolRequest = chat.toolRequest != null,
-            autoApproveTools = chat.autoApproveTools,
-            onToggleAutoApprove = { scope.launch { chatFlow.toggleAutoApproveTools() } },
-            onAllowTool = { scope.launch { chatFlow.resolveToolPermission(true, false) } },
-            onAlwaysAllowTool = { scope.launch { chatFlow.resolveToolPermission(true, true) } },
-            onDenyTool = { scope.launch { chatFlow.resolveToolPermission(false, false) } },
-            onNewChat = { scope.launch { newChat() } },
+            onSelectRole = { idx -> scope.launch { rolesInteractor.selectRole(idx); emitChatState(chat) } },
+            onSelectPreset = { idx -> scope.launch { presetsInteractor.selectPreset(idx); emitChatState(chat) } },
+            onSendMessage = { text -> scope.launch {
+                if (presetsInteractor.presets.presets.isEmpty()) {
+                    presetsInteractor.startCreatePreset(); emitPresetsState()
+                } else {
+                    chatInteractor.send(text)
+                }
+            } },
+            onStop = { chatInteractor.stop() },
+            onDeleteFrom = { idx -> scope.launch { chatInteractor.deleteFrom(idx) } },
+            onToggleAutoApprove = { scope.launch { chatInteractor.toggleAutoApproveTools() } },
+            onAllowTool = { scope.launch { chatInteractor.resolveToolPermission(true, false) } },
+            onAlwaysAllowTool = { scope.launch { chatInteractor.resolveToolPermission(true, true) } },
+            onDenyTool = { scope.launch { chatInteractor.resolveToolPermission(false, false) } },
+            onNewChat = { scope.launch { chatInteractor.newChat() } },
             onOpenHistory = { scope.launch { showHistory() } },
             onOpenRoles = { scope.launch { showRoles() } },
             onOpenPresets = { scope.launch { showPresets() } },
             onOpenServers = { scope.launch { showServers() } },
         )
-    }
-
-    private fun createListState(chats: List<ChatSummary>) = State.ChatListState(
-        chats = chats.filter { it.messages != 0 }.map { it.toUi() },
-        onOpenChat = { id -> scope.launch { openChat(id) } },
-        onDeleteChat = { id -> scope.launch { deleteChat(id) } },
-        onNewChat = { scope.launch { newChat() } },
-        onOpenRoles = { scope.launch { showRoles() } },
-        onOpenPresets = { scope.launch { showPresets() } },
-        onOpenServers = { scope.launch { showServers() } },
-    )
-
-    private fun createRolesState(): State.RolesState {
-        val text = if (creatingRole) "" else roles.roles[roles.active].text
-        return State.RolesState(
-            roles = roles.roles.map { it.name },
-            currentIndex = roles.active,
-            creating = creatingRole,
-            text = text,
-            onSelectRole = { idx -> scope.launch {
-                selectRole(idx)
-                _state.emit(createRolesState())
-            } },
-            onStartCreateRole = { scope.launch { startCreateRole() } },
-            onAddRole = { name, t -> scope.launch { addRole(name, t) } },
-            onDeleteRole = { scope.launch { deleteRole() } },
-            onSave = { t -> scope.launch { saveRole(t) } },
-            onNewChat = { scope.launch { newChat() } },
-            onOpenHistory = { scope.launch { showHistory() } },
-            onOpenRoles = { },
-            onOpenPresets = { scope.launch { showPresets() } },
-            onOpenServers = { scope.launch { showServers() } },
-        )
+        _state.emit(state)
     }
 
     private suspend fun showHistory() {
-        val chats = chatRepository.listChats()
-        _state.emit(createListState(chats))
+        val chats = chatInteractor.listChats()
+        val state = factory.createChatListState(
+            chats = chats,
+            onOpenChat = { id -> scope.launch { chatInteractor.openChat(id) } },
+            onDeleteChat = { id -> scope.launch { chatInteractor.deleteChat(id); showHistory() } },
+            onNewChat = { scope.launch { chatInteractor.newChat() } },
+            onOpenRoles = { scope.launch { showRoles() } },
+            onOpenPresets = { scope.launch { showPresets() } },
+            onOpenServers = { scope.launch { showServers() } },
+        )
+        _state.emit(state)
     }
 
     private suspend fun showRoles() {
-        roles = rolesRepository.load()
-        creatingRole = false
-        _state.emit(createRolesState())
+        rolesInteractor.load()
+        rolesInteractor.finishCreateRole()
+        emitRolesState()
+    }
+
+    private suspend fun emitRolesState() {
+        val roles = rolesInteractor.roles
+        val creating = rolesInteractor.creatingRole
+        val text = if (creating) "" else roles.roles[roles.active].text
+        val state = factory.createRolesState(
+            roles = roles,
+            creatingRole = creating,
+            text = text,
+            onSelectRole = { idx -> scope.launch { rolesInteractor.selectRole(idx); emitRolesState() } },
+            onStartCreateRole = { rolesInteractor.startCreateRole(); scope.launch { emitRolesState() } },
+            onAddRole = { name, t -> scope.launch { rolesInteractor.addRole(name, t); emitRolesState() } },
+            onDeleteRole = { scope.launch { rolesInteractor.deleteRole(); emitRolesState() } },
+            onSave = { t -> scope.launch { rolesInteractor.saveRole(t); emitRolesState() } },
+            onNewChat = { scope.launch { chatInteractor.newChat() } },
+            onOpenHistory = { scope.launch { showHistory() } },
+            onOpenPresets = { scope.launch { showPresets() } },
+            onOpenServers = { scope.launch { showServers() } },
+        )
+        _state.emit(state)
     }
 
     private suspend fun showPresets() {
-        presets = presetsRepository.load()
-        if (presets.presets.isEmpty()) creatingPreset = true
-        _state.emit(createPresetsState())
+        presetsInteractor.load()
+        if (presetsInteractor.presets.presets.isEmpty()) presetsInteractor.startCreatePreset() else presetsInteractor.finishCreatePreset()
+        emitPresetsState()
     }
 
-    private suspend fun showServers() {
-        _state.emit(createServersState())
-    }
-
-    private suspend fun newChat() {
-        val lastChat = chatRepository.listChats().firstOrNull()?.id ?: run {
-            chatFlow.loadChat(chatRepository.createChat())
-            return
-        }
-
-        if (chatRepository.loadMessages(lastChat).isEmpty()) {
-            openChat(lastChat)
-        } else {
-            chatFlow.loadChat(chatRepository.createChat())
-        }
-    }
-
-    private suspend fun openChat(id: String) = chatFlow.loadChat(id)
-
-    private suspend fun saveRole(text: String) {
-        val list = roles.roles.toMutableList()
-        list[roles.active] = list[roles.active].copy(text = text)
-        roles = roles.copy(roles = list)
-        rolesRepository.save(roles)
-        _state.emit(createRolesState())
-    }
-
-    private suspend fun selectRole(idx: Int) {
-        roles = roles.copy(active = idx)
-        rolesRepository.save(roles)
-    }
-
-    suspend fun selectRole(role: DefaultRoles) {
-        val idx = roles.roles.indexOfFirst { it.name == role.displayName }
-        if (idx >= 0) {
-            selectRole(idx)
-            _state.emit(createChatState(currentChat))
-        }
-    }
-
-    private suspend fun startCreateRole() {
-        creatingRole = true
-        _state.emit(createRolesState())
-    }
-
-    private suspend fun addRole(name: String, text: String) {
-        roles = Roles(
-            active = roles.roles.size,
-            roles = roles.roles + Role(name, text)
-        )
-        creatingRole = false
-        rolesRepository.save(roles)
-        _state.emit(createRolesState())
-    }
-
-    private suspend fun deleteRole() {
-        val currentName = roles.roles[roles.active].name
-        if (currentName in DefaultRoles.NAMES) return
-        val list = roles.roles.toMutableList()
-        list.removeAt(roles.active)
-        val newActive = roles.active.coerceAtMost(list.lastIndex)
-        roles = Roles(active = newActive, roles = list)
-        rolesRepository.save(roles)
-        _state.emit(createRolesState())
-    }
-
-    private suspend fun deleteChat(id: String) {
-        chatRepository.deleteChat(id)
-        if (chatRepository.listChats().isEmpty()) {
-            newChat()
-        } else {
-            showHistory()
-        }
-    }
-
-    private suspend fun send(text: String) {
-        if (presets.presets.isEmpty()) {
-            creatingPreset = true
-            _state.emit(createPresetsState())
-        } else {
-            chatFlow.send(text)
-        }
-    }
-    private fun stop() {
-        chatFlow.stop()
-        mcpManager.stop()
-    }
-    private suspend fun deleteFrom(idx: Int) = chatFlow.deleteFrom(idx)
-
-    private fun createPresetsState(): State.PresetsState {
-        val emptyPresets = presets.presets.isEmpty()
-        val preset = if (creatingPreset || emptyPresets) {
-            val defaultProvider = LlmProviders.default
+    private suspend fun emitPresetsState() {
+        val presets = presetsInteractor.presets
+        val creating = presetsInteractor.creatingPreset
+        val empty = presets.presets.isEmpty()
+        val preset = if (creating || empty) {
+            val defaultProvider = io.qent.sona.core.presets.LlmProviders.default
             Preset(
                 name = defaultProvider.models.first().name,
                 provider = defaultProvider,
@@ -274,89 +178,35 @@ class StateProvider(
         } else {
             presets.presets[presets.active]
         }
-        return State.PresetsState(
-            presets = presets.presets.map { it.name },
-            currentIndex = presets.active,
-            creating = creatingPreset || emptyPresets,
+        val state = factory.createPresetsState(
+            presets = presets,
+            creatingPreset = creating || presets.presets.isEmpty(),
             preset = preset,
-            onSelectPreset = { idx -> scope.launch { selectPreset(idx) } },
-            onStartCreatePreset = { scope.launch { startCreatePreset() } },
-            onAddPreset = { p -> scope.launch { addPreset(p) } },
-            onDeletePreset = { scope.launch { deletePreset() } },
-            onSave = { p -> scope.launch { savePreset(p) } },
-            onNewChat = { scope.launch { newChat() } },
+            onSelectPreset = { idx -> scope.launch { presetsInteractor.selectPreset(idx); emitPresetsState() } },
+            onStartCreatePreset = { presetsInteractor.startCreatePreset(); scope.launch { emitPresetsState() } },
+            onAddPreset = { p -> scope.launch { presetsInteractor.addPreset(p); chatInteractor.newChat() } },
+            onDeletePreset = { scope.launch { presetsInteractor.deletePreset(); emitPresetsState() } },
+            onSave = { p -> scope.launch { presetsInteractor.savePreset(p); emitPresetsState() } },
+            onNewChat = { scope.launch { chatInteractor.newChat() } },
             onOpenHistory = { scope.launch { showHistory() } },
             onOpenRoles = { scope.launch { showRoles() } },
             onOpenServers = { scope.launch { showServers() } },
         )
+        _state.emit(state)
     }
 
-    private fun createServersState(): State.ServersState = State.ServersState(
-        servers = mcpManager.servers,
-        onToggleServer = { name -> mcpManager.toggle(name) },
-        onReload = { scope.launch { mcpManager.reload() } },
-        onEditConfig = editConfig,
-        onNewChat = { scope.launch { newChat() } },
-        onOpenHistory = { scope.launch { showHistory() } },
-        onOpenRoles = { scope.launch { showRoles() } },
-        onOpenPresets = { scope.launch { showPresets() } },
-    )
-
-    private suspend fun selectChatPreset(idx: Int) {
-        presets = presets.copy(active = idx)
-        presetsRepository.save(presets)
-        _state.emit(createChatState(currentChat))
-    }
-
-    private suspend fun selectPreset(idx: Int) {
-        presets = presets.copy(active = idx)
-        presetsRepository.save(presets)
-        _state.emit(createPresetsState())
-    }
-
-    private suspend fun startCreatePreset() {
-        creatingPreset = true
-        _state.emit(createPresetsState())
-    }
-
-    private suspend fun addPreset(preset: Preset) {
-        presets = Presets(
-            active = presets.presets.size,
-            presets = presets.presets + preset,
+    private suspend fun showServers() {
+        val state = factory.createServersState(
+            servers = serversInteractor.servers,
+            onToggleServer = { name -> serversInteractor.toggle(name) },
+            onReload = { scope.launch { serversInteractor.reload() } },
+            onEditConfig = editConfig,
+            onNewChat = { scope.launch { chatInteractor.newChat() } },
+            onOpenHistory = { scope.launch { showHistory() } },
+            onOpenRoles = { scope.launch { showRoles() } },
+            onOpenPresets = { scope.launch { showPresets() } },
         )
-        creatingPreset = false
-        presetsRepository.save(presets)
-
-        newChat()
-    }
-
-    private suspend fun deletePreset() {
-        if (presets.presets.isEmpty()) return
-        val list = presets.presets.toMutableList()
-        list.removeAt(presets.active)
-        val newActive = presets.active.coerceAtMost(list.lastIndex).coerceAtLeast(0)
-        presets = Presets(newActive, list)
-        presetsRepository.save(presets)
-        _state.emit(createPresetsState())
-    }
-
-    private suspend fun savePreset(preset: Preset) {
-        val list = presets.presets.toMutableList()
-        if (list.isNotEmpty()) {
-            list[presets.active] = preset
-            presets = presets.copy(presets = list)
-            presetsRepository.save(presets)
-        }
-        _state.emit(createPresetsState())
+        _state.emit(state)
     }
 }
 
-private fun ChatRepositoryMessage.toUiMessage(): UiMessage? = when (val m = message) {
-    is AiMessage -> UiMessage.Ai(m.text().orEmpty(), m.toolExecutionRequests())
-    is UserMessage -> UiMessage.User(m.singleText().trim())
-    is ToolExecutionResultMessage -> UiMessage.Tool(m.text())
-    else -> null
-}
-
-private fun ChatSummary.toUi(): UiChatSummary =
-    UiChatSummary(id, firstMessage, messages, createdAt)

--- a/core/src/test/kotlin/io/qent/sona/core/state/ChatStateInteractorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/state/ChatStateInteractorTest.kt
@@ -1,0 +1,70 @@
+package io.qent.sona.core.state
+
+import dev.langchain4j.data.message.ChatMessage
+import io.qent.sona.core.chat.Chat
+import io.qent.sona.core.chat.ChatRepository
+import io.qent.sona.core.chat.ChatRepositoryMessage
+import io.qent.sona.core.chat.ChatSummary
+import io.qent.sona.core.model.TokenUsageInfo
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+private class FakeChatRepository : ChatRepository {
+    var chats = mutableListOf<ChatSummary>()
+    var messages = mutableMapOf<String, MutableList<ChatRepositoryMessage>>()
+    var counter = 0
+    override suspend fun createChat(): String {
+        val id = (++counter).toString()
+        chats.add(ChatSummary(id, "", 0, 0))
+        messages[id] = mutableListOf()
+        return id
+    }
+    override suspend fun addMessage(chatId: String, message: ChatMessage, model: String, tokenUsage: TokenUsageInfo) {}
+    override suspend fun loadMessages(chatId: String): List<ChatRepositoryMessage> = messages[chatId] ?: emptyList()
+    override suspend fun loadTokenUsage(chatId: String) = TokenUsageInfo()
+    override suspend fun isToolAllowed(chatId: String, toolName: String) = false
+    override suspend fun addAllowedTool(chatId: String, toolName: String) {}
+    override suspend fun listChats(): List<ChatSummary> = chats
+    override suspend fun deleteChat(chatId: String) { chats.removeIf { it.id == chatId }; messages.remove(chatId) }
+    override suspend fun deleteMessagesFrom(chatId: String, index: Int) {}
+}
+
+private class FakeChatFlow : ChatSession {
+    private val flow = MutableSharedFlow<Chat>()
+    var lastLoaded: String? = null
+    override suspend fun loadChat(id: String) { lastLoaded = id }
+    override suspend fun send(text: String) {}
+    override fun stop() {}
+    override suspend fun deleteFrom(idx: Int) {}
+    override fun toggleAutoApproveTools() {}
+    override suspend fun resolveToolPermission(allow: Boolean, always: Boolean) {}
+    override suspend fun collect(collector: FlowCollector<Chat>) { flow.collect(collector) }
+}
+
+class ChatStateInteractorTest {
+    @Test
+    fun newChatLoadsExistingWhenEmpty() = runBlocking {
+        val repo = FakeChatRepository()
+        val chatId = repo.createChat()
+        val flow = FakeChatFlow()
+        val interactor = ChatStateInteractor(flow, repo)
+        interactor.newChat()
+        assertEquals(chatId, flow.lastLoaded)
+    }
+
+    @Test
+    fun newChatCreatesWhenLastHasMessages() = runBlocking {
+        val repo = FakeChatRepository()
+        val existing = repo.createChat()
+        repo.messages[existing]?.add(ChatRepositoryMessage(existing, dev.langchain4j.data.message.UserMessage.from("hi"), "m"))
+        val flow = FakeChatFlow()
+        val interactor = ChatStateInteractor(flow, repo)
+        interactor.newChat()
+        assertNotEquals(existing, flow.lastLoaded)
+    }
+}
+

--- a/core/src/test/kotlin/io/qent/sona/core/state/PresetsStateInteractorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/state/PresetsStateInteractorTest.kt
@@ -1,0 +1,29 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.presets.LlmProvider
+import io.qent.sona.core.presets.Preset
+import io.qent.sona.core.presets.Presets
+import io.qent.sona.core.presets.PresetsRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private class FakePresetsRepository(var data: Presets = Presets(0, emptyList())) : PresetsRepository {
+    override suspend fun load(): Presets = data
+    override suspend fun save(presets: Presets) { data = presets }
+}
+
+class PresetsStateInteractorTest {
+    @Test
+    fun addPresetUpdatesRepository() = runBlocking {
+        val provider = LlmProvider("p", "e", emptyList())
+        val repo = FakePresetsRepository(Presets(0, emptyList()))
+        val interactor = PresetsStateInteractor(repo)
+        interactor.load()
+        interactor.startCreatePreset()
+        interactor.addPreset(Preset("n", provider, "e", "m", "k"))
+        assertEquals(1, repo.data.presets.size)
+        assertEquals(0, repo.data.active)
+    }
+}
+

--- a/core/src/test/kotlin/io/qent/sona/core/state/RolesStateInteractorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/state/RolesStateInteractorTest.kt
@@ -1,0 +1,27 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.roles.Role
+import io.qent.sona.core.roles.Roles
+import io.qent.sona.core.roles.RolesRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private class FakeRolesRepository(var data: Roles = Roles(0, emptyList())) : RolesRepository {
+    override suspend fun load(): Roles = data
+    override suspend fun save(roles: Roles) { data = roles }
+}
+
+class RolesStateInteractorTest {
+    @Test
+    fun addRoleUpdatesRepository() = runBlocking {
+        val repo = FakeRolesRepository(Roles(0, listOf(Role("A", "a"))))
+        val interactor = RolesStateInteractor(repo)
+        interactor.load()
+        interactor.startCreateRole()
+        interactor.addRole("B", "b")
+        assertEquals(2, repo.data.roles.size)
+        assertEquals(1, repo.data.active)
+    }
+}
+

--- a/core/src/test/kotlin/io/qent/sona/core/state/ServersStateInteractorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/state/ServersStateInteractorTest.kt
@@ -1,0 +1,26 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.mcp.McpServerStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private class FakeServersController : ServersController {
+    val toggled = mutableListOf<String>()
+    override val servers = MutableStateFlow<List<McpServerStatus>>(emptyList())
+    override fun toggle(name: String) { toggled.add(name) }
+    override suspend fun reload() { }
+    override fun stop() {}
+}
+
+class ServersStateInteractorTest {
+    @Test
+    fun toggleDelegatesToController() = runBlocking {
+        val controller = FakeServersController()
+        val interactor = ServersStateInteractor(controller)
+        interactor.toggle("a")
+        assertTrue(controller.toggled.contains("a"))
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extract chat, roles, presets and server logic into dedicated interactors
- Introduce StateFactory and slim StateProvider facade
- Add unit tests for all interactors and enable JUnit in core module

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6894e7d13284832085676dabc0970856