### PR TITLE
Allow disabling individual MCP server tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,11 +56,12 @@ File permissions can also be adjusted by adding a `sona.json` file at the projec
 `permissions.files.whitelist` and `blacklist` arrays of regex patterns.
 `sona.json` may additionally define an `mcpServers` object keyed by server name with Model
 Context Protocol server configurations including `enabled`, `command`, `args`, environment
-variables, transport, URL, working directory and request headers. Supported transports are
-`stdio` and `http` and each server runs in its own coroutine so failures are isolated. Tools
-exposed by these servers require the same user permission prompts as local tools. Server
-enablement is stored in `sona.json` and only servers marked as enabled reconnect automatically
-on restart.
+variables, transport, URL, working directory, request headers and an optional
+`disabledTools` array listing tool names to ignore. Supported transports are `stdio` and
+`http` and each server runs in its own coroutine so failures are isolated. Tools exposed by
+these servers require the same user permission prompts as local tools. Server enablement and
+disabled tools are stored in `sona.json`; only servers marked as enabled reconnect
+automatically on restart.
 `ChatFlow` depends only on the `Tools` interface and receives the decorator from `StateProvider`.
 
 Whenever you extend the logic make sure the flow of state remains unidirectional

--- a/README.md
+++ b/README.md
@@ -117,12 +117,19 @@ green once connected and exposing tools. Clicking a card toggles the server on o
 the list reloads `sona.json` and reconnects previously enabled servers. A pinned **Редактировать конфигурацию**
 button at the bottom opens `sona.json`, creating it with the current server configuration and file permission
 lists when missing. Server enablement is stored in `sona.json` so only servers marked as enabled start
-automatically after restarting the IDE.
+automatically after restarting the IDE. Connected servers expand to show their tools with a green indicator next
+to each one. Clicking the indicator disables the tool, turning it grey and excluding it from future LLM requests.
+Disabled tool names persist in `sona.json` under the server's `disabledTools` array.
 
 ```json
 {
   "mcpServers": {
-    "calc": { "enabled": true, "command": "calc-mcp", "transport": "stdio" },
+    "calc": {
+      "enabled": true,
+      "command": "calc-mcp",
+      "transport": "stdio",
+      "disabledTools": ["multiply"]
+    },
     "weather": { "enabled": false, "url": "https://example.com/mcp", "transport": "http" }
   }
 }

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpServerStatus.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpServerStatus.kt
@@ -8,7 +8,8 @@ import dev.langchain4j.agent.tool.ToolSpecification
 data class McpServerStatus(
     val name: String,
     val status: Status,
-    val tools: List<ToolSpecification>
+    val tools: List<ToolSpecification>,
+    val disabledTools: Set<String> = emptySet()
 ) {
     sealed interface Status {
         /** The server is turned off and no information is sent to the LLM. */

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpServersRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpServersRepository.kt
@@ -15,4 +15,6 @@ interface McpServersRepository {
     suspend fun list(): List<McpServerConfig>
     suspend fun loadEnabled(): Set<String>
     suspend fun saveEnabled(enabled: Set<String>)
+    suspend fun loadDisabledTools(): Map<String, Set<String>>
+    suspend fun saveDisabledTools(disabled: Map<String, Set<String>>)
 }

--- a/core/src/main/kotlin/io/qent/sona/core/state/ServersStateInteractor.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/ServersStateInteractor.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.StateFlow
 interface ServersController {
     val servers: StateFlow<List<McpServerStatus>>
     fun toggle(name: String)
+    fun toggleTool(server: String, tool: String)
     suspend fun reload()
     fun stop()
 }
@@ -14,6 +15,7 @@ class ServersStateInteractor(private val controller: ServersController) {
     val servers: StateFlow<List<McpServerStatus>> = controller.servers
 
     fun toggle(name: String) = controller.toggle(name)
+    fun toggleTool(server: String, tool: String) = controller.toggleTool(server, tool)
 
     suspend fun reload() = controller.reload()
 

--- a/core/src/main/kotlin/io/qent/sona/core/state/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/State.kt
@@ -105,6 +105,7 @@ sealed class State {
     data class ServersState(
         val servers: StateFlow<List<McpServerStatus>>,
         val onToggleServer: (String) -> Unit,
+        val onToggleTool: (String, String) -> Unit,
         val onReload: () -> Unit,
         val onEditConfig: () -> Unit,
         override val onNewChat: () -> Unit,

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateFactory.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateFactory.kt
@@ -142,6 +142,7 @@ class StateFactory {
     fun createServersState(
         servers: StateFlow<List<McpServerStatus>>,
         onToggleServer: (String) -> Unit,
+        onToggleTool: (String, String) -> Unit,
         onReload: () -> Unit,
         onEditConfig: () -> Unit,
         onNewChat: () -> Unit,
@@ -151,6 +152,7 @@ class StateFactory {
     ) = State.ServersState(
         servers = servers,
         onToggleServer = onToggleServer,
+        onToggleTool = onToggleTool,
         onReload = onReload,
         onEditConfig = onEditConfig,
         onNewChat = onNewChat,

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
@@ -55,6 +55,7 @@ class StateProvider(
     private val serversInteractor = ServersStateInteractor(object : ServersController {
         override val servers = mcpManager.servers
         override fun toggle(name: String) = mcpManager.toggle(name)
+        override fun toggleTool(server: String, tool: String) = mcpManager.toggleTool(server, tool)
         override suspend fun reload() = mcpManager.reload()
         override fun stop() = mcpManager.stop()
     })
@@ -199,6 +200,7 @@ class StateProvider(
         val state = factory.createServersState(
             servers = serversInteractor.servers,
             onToggleServer = { name -> serversInteractor.toggle(name) },
+            onToggleTool = { server, tool -> serversInteractor.toggleTool(server, tool) },
             onReload = { scope.launch { serversInteractor.reload() } },
             onEditConfig = editConfig,
             onNewChat = { scope.launch { chatInteractor.newChat() } },

--- a/core/src/test/kotlin/io/qent/sona/core/state/ServersStateInteractorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/state/ServersStateInteractorTest.kt
@@ -8,8 +8,10 @@ import org.junit.Test
 
 private class FakeServersController : ServersController {
     val toggled = mutableListOf<String>()
+    val toggledTools = mutableListOf<Pair<String, String>>()
     override val servers = MutableStateFlow<List<McpServerStatus>>(emptyList())
     override fun toggle(name: String) { toggled.add(name) }
+    override fun toggleTool(server: String, tool: String) { toggledTools.add(server to tool) }
     override suspend fun reload() { }
     override fun stop() {}
 }
@@ -21,6 +23,14 @@ class ServersStateInteractorTest {
         val interactor = ServersStateInteractor(controller)
         interactor.toggle("a")
         assertTrue(controller.toggled.contains("a"))
+    }
+
+    @Test
+    fun toggleToolDelegatesToController() = runBlocking {
+        val controller = FakeServersController()
+        val interactor = ServersStateInteractor(controller)
+        interactor.toggleTool("s", "t")
+        assertTrue(controller.toggledTools.contains("s" to "t"))
     }
 }
 

--- a/src/main/kotlin/io/qent/sona/config/SonaConfig.kt
+++ b/src/main/kotlin/io/qent/sona/config/SonaConfig.kt
@@ -26,6 +26,7 @@ class SonaConfig {
         var url: String? = null
         var cwd: String? = null
         var headers: Map<String, String>? = null
+        var disabledTools: List<String>? = null
     }
 
     companion object {

--- a/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
@@ -63,6 +63,25 @@ class PluginMcpServersRepository(private val project: Project) : McpServersRepos
         SonaConfig.save(root, config)
     }
 
+    override suspend fun loadDisabledTools(): Map<String, Set<String>> {
+        val servers = SonaConfig.load(root)?.mcpServers ?: emptyMap()
+        return servers.mapValues { it.value.disabledTools?.toSet() ?: emptySet() }
+    }
+
+    override suspend fun saveDisabledTools(disabled: Map<String, Set<String>>) {
+        val file = File(root, "sona.json")
+        if (!file.exists()) return
+        val config = SonaConfig.load(root) ?: SonaConfig()
+        val servers = config.mcpServers?.toMutableMap() ?: mutableMapOf()
+        disabled.forEach { (name, set) ->
+            val server = servers[name] ?: SonaConfig.McpServer()
+            server.disabledTools = set.toList()
+            servers[name] = server
+        }
+        config.mcpServers = servers
+        SonaConfig.save(root, config)
+    }
+
     fun openConfig() {
         val file = File(root, "sona.json")
         if (!file.exists()) {

--- a/src/main/kotlin/io/qent/sona/ui/mcp/ServersPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/mcp/ServersPanel.kt
@@ -132,12 +132,22 @@ fun ServersPanel(state: State.ServersState) {
                         is McpServerStatus.Status.CONNECTED -> {
                             if (expanded.value) {
                                 for (tool in server.tools) {
+                                    val disabled = server.disabledTools.contains(tool.name())
                                     Row(
                                         Modifier
                                             .fillMaxWidth()
                                             .padding(top = 12.dp),
-                                        verticalAlignment = Alignment.Top
+                                        verticalAlignment = Alignment.CenterVertically
                                     ) {
+                                        val color = if (disabled) Color.Gray else Color(0xFF4CAF50)
+                                        Box(
+                                            Modifier
+                                                .clickable { state.onToggleTool(server.name, tool.name()) }
+                                                .padding(end = 8.dp)
+                                                .size(8.dp)
+                                                .clip(CircleShape)
+                                                .background(color)
+                                        )
                                         Text(tool.name(), Modifier.width(200.dp), fontWeight = FontWeight.Bold)
                                         Text(
                                             tool.description().trimIndent(),


### PR DESCRIPTION
## Summary
- Let users disable MCP server tools from the Servers panel with clickable green/gray indicators
- Persist disabled tool names in `sona.json` and filter them out of requests
- Document MCP tool disabling support

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6894ef113e6083208af3e10fb38f43e6