### PR TITLE
Add Custom OpenAI provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@
 - LLM connection details are organised as presets via `PresetsRepository`. At least one preset must exist for the chat
   to work and they are managed from the Presets screen.
 - Supported LLM providers and models are defined in `core/src/main/resources/providers.json` so new options can be
-  added without modifying the code.
+  added without modifying the code. A `Custom OpenAI` provider is registered in code for manual model entry and
+  always reports zero token cost.
 - Plugin settings contain an "Ignore HTTPS errors" flag and an "Anthropic Settings"
   section to cache system prompts and tool descriptions in requests.
 - Each chat tracks tools approved by the user so that previously allowed tools run without asking again.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ LLM credentials are stored as presets. Each preset defines the provider, model,
 API endpoint and token. Manage presets from the Presets screen opened via the
 tool window actions. At least one preset must exist for the chat to function.
 Supported providers and their models are listed in `core/src/main/resources/providers.json`
-so new options can be added without touching the code.
+so new options can be added without touching the code. A `Custom OpenAI` provider is
+available for manual model entry and is defined directly in code.
 
 The chat header shows token usage together with the estimated cost for the last
 message and for the entire conversation. It also displays how much of the
@@ -62,8 +63,8 @@ sending requests to Anthropic models.
 ## Model pricing
 
 Token costs are loaded from `providers.json` so conversations can display their
-estimated price. The rates below are in USD per million tokens and are based on
-the official pricing pages.
+estimated price. The `Custom OpenAI` provider always reports zero cost. The rates
+below are in USD per million tokens and are based on the official pricing pages.
 
 | Provider | Model | Input | Output | Source |
 | --- | --- | --- | --- | --- |

--- a/core/src/main/kotlin/io/qent/sona/core/presets/PresetsRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/presets/PresetsRepository.kt
@@ -25,10 +25,18 @@ object LlmProviders {
     private val gson = Gson()
     private val type = object : TypeToken<List<LlmProvider>>() {}.type
 
+    private val customOpenAi = LlmProvider(
+        name = "Custom OpenAI",
+        defaultEndpoint = "https://api.openai.com/v1/",
+        models = emptyList(),
+    )
+
     val entries: List<LlmProvider> by lazy {
-        LlmProviders::class.java.getResourceAsStream("/providers.json")!!.use { stream ->
-            gson.fromJson(stream.reader(), type)
-        }
+        val jsonProviders: List<LlmProvider> =
+            LlmProviders::class.java.getResourceAsStream("/providers.json")!!.use { stream ->
+                gson.fromJson(stream.reader(), type)
+            }
+        jsonProviders + customOpenAi
     }
 
     fun find(name: String): LlmProvider? = entries.find { it.name == name }

--- a/src/main/kotlin/io/qent/sona/repositories/PluginPresetsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginPresetsRepository.kt
@@ -43,7 +43,7 @@ class PluginPresetsRepository : PresetsRepository,
                 stored.name,
                 provider,
                 stored.apiEndpoint.ifEmpty { provider.defaultEndpoint },
-                stored.model.ifEmpty { provider.models.first().name },
+                stored.model.ifEmpty { provider.models.firstOrNull()?.name ?: "" },
                 stored.apiKey,
             )
         }

--- a/src/main/kotlin/io/qent/sona/ui/presets/PresetsPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/presets/PresetsPanel.kt
@@ -91,7 +91,7 @@ fun PresetsPanel(state: State.PresetsState) {
                     Column {
                         PresetForm(nameState, provider, {
                             provider = it
-                            model = it.models.first().name
+                            model = it.models.firstOrNull()?.name ?: ""
                             apiState.setTextAndPlaceCursorAtEnd(it.defaultEndpoint)
                         }, model, { model = it }, apiState, tokenState)
                         Spacer(Modifier.height(12.dp))
@@ -137,7 +137,7 @@ fun PresetsPanel(state: State.PresetsState) {
                 Spacer(Modifier.height(8.dp))
                 PresetForm(nameState, provider, {
                     provider = it
-                    model = it.models.first().name
+                    model = it.models.firstOrNull()?.name ?: ""
                     apiState.setTextAndPlaceCursorAtEnd(it.defaultEndpoint)
                 }, model, { model = it }, apiState, tokenState)
                 Spacer(Modifier.height(8.dp))
@@ -189,15 +189,22 @@ private fun PresetForm(
         Spacer(Modifier.height(12.dp))
           Text(Strings.model)
         Spacer(Modifier.height(2.dp))
-        DropdownSelector(
-            items = provider.models.map { it.name },
-            selectedIndex = provider.models.indexOfFirst { it.name == model }.coerceAtLeast(0),
-            expandUpwards = false,
-            onSelect = { idx -> onModelChange(provider.models[idx].name) },
-            modifier = Modifier.fillMaxWidth(),
-            backgroundColor = SonaTheme.colors.Background,
-            buttonModifier = Modifier.fillMaxWidth()
-        )
+        if (provider.models.isEmpty()) {
+            val modelState = rememberTextFieldState(model)
+            LaunchedEffect(model) { modelState.setTextAndPlaceCursorAtEnd(model) }
+            TextField(modelState, Modifier.fillMaxWidth())
+            LaunchedEffect(modelState.text) { onModelChange(modelState.text.toString()) }
+        } else {
+            DropdownSelector(
+                items = provider.models.map { it.name },
+                selectedIndex = provider.models.indexOfFirst { it.name == model }.coerceAtLeast(0),
+                expandUpwards = false,
+                onSelect = { idx -> onModelChange(provider.models[idx].name) },
+                modifier = Modifier.fillMaxWidth(),
+                backgroundColor = SonaTheme.colors.Background,
+                buttonModifier = Modifier.fillMaxWidth(),
+            )
+        }
         Spacer(Modifier.height(12.dp))
           Text(Strings.apiUrl)
         Spacer(Modifier.height(6.dp))


### PR DESCRIPTION
## Summary
- add in-code `Custom OpenAI` provider with zero token costs
- allow manual model entry for custom provider presets
- document custom provider and zero-cost behavior

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689586ffbf3c83208de0864b30b1fd2c