### PR TITLE
Extract patch detection utility and add tests

### DIFF
--- a/src/main/kotlin/io/qent/sona/ui/chat/CopyableCodeBlock.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/CopyableCodeBlock.kt
@@ -26,6 +26,7 @@ import com.mikepenz.markdown.compose.elements.MarkdownCodeFence
 import io.qent.sona.PluginStateFlow
 import io.qent.sona.Strings
 import io.qent.sona.services.PatchService
+import io.qent.sona.util.isPatch
 import com.intellij.openapi.components.service
 import java.awt.Cursor
 import java.awt.event.MouseAdapter
@@ -45,14 +46,7 @@ fun CopyableCodeBlock(project: Project, model: MarkdownComponentModel, key: Any,
     if (fence) {
         MarkdownCodeFence(model.content, model.node, style = model.typography.code) { code: String, lang: String?, _ ->
             val isPatch = remember(code, lang) {
-                val l = lang?.lowercase()
-                when {
-                    l != null && (l == "diff" || l == "patch" || l == "udiff") -> true
-                    else -> {
-                        val lines = code.lines()
-                        lines.size >= 2 && lines[0].startsWith("---") && lines[1].startsWith("+++")
-                    }
-                }
+                isPatch(code, lang)
             }
             CodeEditor(project, code, lang, key, isPatch, onScrollOutside = onScrollOutside) {
                 clipboard.setText(AnnotatedString(code))
@@ -61,8 +55,7 @@ fun CopyableCodeBlock(project: Project, model: MarkdownComponentModel, key: Any,
     } else {
         MarkdownCodeBlock(model.content, model.node, style = model.typography.code) { code: String, lang: String?, _ ->
             val isPatch = remember(code) {
-                val lines = code.lines()
-                lines.size >= 2 && lines[0].startsWith("---") && lines[1].startsWith("+++")
+                isPatch(code)
             }
             CodeEditor(project, code, lang, key, isPatch, onScrollOutside = onScrollOutside) {
                 clipboard.setText(AnnotatedString(code))

--- a/src/main/kotlin/io/qent/sona/util/PatchUtils.kt
+++ b/src/main/kotlin/io/qent/sona/util/PatchUtils.kt
@@ -1,0 +1,12 @@
+package io.qent.sona.util
+
+fun isPatch(text: String, lang: String? = null): Boolean {
+    val l = lang?.lowercase()
+    return when {
+        l != null && (l == "diff" || l == "patch" || l == "udiff") -> true
+        else -> {
+            val lines = text.lines()
+            lines.size >= 2 && lines[0].startsWith("---") && lines[1].startsWith("+++")
+        }
+    }
+}

--- a/src/test/kotlin/io/qent/sona/util/PatchUtilsTest.kt
+++ b/src/test/kotlin/io/qent/sona/util/PatchUtilsTest.kt
@@ -1,0 +1,45 @@
+package io.qent.sona.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PatchUtilsTest {
+    @Test
+    fun detectsPatchByLanguage() {
+        val code = "random text"
+        assertTrue(isPatch(code, "diff"))
+        assertTrue(isPatch(code, "patch"))
+        assertTrue(isPatch(code, "udiff"))
+    }
+
+    @Test
+    fun detectsPatchByContent() {
+        val patch = """
+            --- a/file.txt
+            +++ b/file.txt
+            @@
+            -old
+            +new
+        """.trimIndent()
+        assertTrue(isPatch(patch))
+    }
+
+    @Test
+    fun rejectsNonPatchContent() {
+        val code = "fun main() {\n println(\"hi\")\n}"
+        assertFalse(isPatch(code))
+        assertFalse(isPatch(code, "kotlin"))
+    }
+
+    @Test
+    fun rejectsIncompletePatchMarkers() {
+        val code = """
+            --- a/file.txt
+            @@
+            -old
+            +new
+        """.trimIndent()
+        assertFalse(isPatch(code))
+    }
+}


### PR DESCRIPTION
## Summary
- move patch detection logic into `PatchUtils.isPatch`
- reuse utility in `CopyableCodeBlock` composable
- add unit tests for patch recognition with various examples

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68964eb3e58883209dc5e43972771178