### PR TITLE
Fix nightly build release asset step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,6 +230,21 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
+      # Set up Java environment for building the plugin
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+
+      # Setup Gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Build plugin archive for the release asset
+      - name: Build plugin
+        run: ./gradlew buildPlugin
+
       # Remove old release drafts by using the curl request for the available releases with a draft flag
       - name: Remove Old Release Drafts
         env:


### PR DESCRIPTION
## Summary
- build plugin in `releaseDraft` job so nightly release asset upload succeeds

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6896539ef2388320b72580ceb73bfb4d