### PR TITLE
ci: run tests on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ on:
   # Trigger the workflow on pushes to only the 'main' branch (this avoids duplicate checks being run e.g., for dependabot pull requests)
   push:
     branches: [ main ]
-  # Trigger the workflow on any pull request
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,20 @@
+name: PR Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run tests
+        run: ./gradlew test

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ you can resume conversations after restarting the IDE.
 
 Use the IDE plugin manager or download the plugin from releases.
 
+## Testing
+
+Pull requests trigger a GitHub Actions workflow that runs the test suite.
+
 ## Nightly builds
 
 A scheduled GitHub Actions workflow runs every night and builds a plugin archive if there were changes in the `main`


### PR DESCRIPTION
## Summary
- run tests for pull requests in a dedicated workflow
- remove pull request trigger from full build workflow
- document PR test workflow in README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689658d92300832086a88ce8aa9c2e6a