### PR TITLE
Refactor roles state management using shared flow

### DIFF
--- a/core/src/main/kotlin/io/qent/sona/core/state/RolesStateFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/RolesStateFlow.kt
@@ -1,0 +1,24 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.roles.Roles
+import io.qent.sona.core.roles.RolesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.FlowCollector
+
+class RolesStateFlow(private val repository: RolesRepository) : StateFlow<Roles> {
+    private val _roles = MutableStateFlow(Roles(0, emptyList()))
+
+    override val replayCache: List<Roles> get() = _roles.replayCache
+    override val value: Roles get() = _roles.value
+    override suspend fun collect(collector: FlowCollector<Roles>) = _roles.collect(collector)
+
+    suspend fun load() {
+        _roles.value = repository.load()
+    }
+
+    suspend fun save(roles: Roles) {
+        _roles.value = roles
+        repository.save(roles)
+    }
+}

--- a/core/src/test/kotlin/io/qent/sona/core/state/RolesStateInteractorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/state/RolesStateInteractorTest.kt
@@ -17,7 +17,8 @@ class RolesStateInteractorTest {
     @Test
     fun addRoleUpdatesRepository() = runBlocking {
         val repo = FakeRolesRepository(Roles(0, listOf(Role("A", "sa", "a"))))
-        val interactor = RolesStateInteractor(repo)
+        val flow = RolesStateFlow(repo)
+        val interactor = RolesStateInteractor(flow)
         interactor.load()
         interactor.startCreateRole()
         interactor.addRole("B", "sb", "b")
@@ -28,7 +29,8 @@ class RolesStateInteractorTest {
     @Test
     fun selectRolePersistsActive() = runBlocking {
         val repo = FakeRolesRepository(Roles(0, listOf(Role("A", "sa", "a"), Role("B", "sb", "b"))))
-        val interactor = RolesStateInteractor(repo)
+        val flow = RolesStateFlow(repo)
+        val interactor = RolesStateInteractor(flow)
         interactor.load()
         interactor.selectRole(1)
         assertEquals(1, repo.data.active)
@@ -37,7 +39,8 @@ class RolesStateInteractorTest {
     @Test
     fun saveRoleUpdatesText() = runBlocking {
         val repo = FakeRolesRepository(Roles(0, listOf(Role("A", "sa", "a"))))
-        val interactor = RolesStateInteractor(repo)
+        val flow = RolesStateFlow(repo)
+        val interactor = RolesStateInteractor(flow)
         interactor.load()
         interactor.saveRole("sn", "new")
         assertEquals("new", repo.data.roles[0].text)
@@ -49,7 +52,8 @@ class RolesStateInteractorTest {
         val repo = FakeRolesRepository(
             Roles(0, listOf(Role(DefaultRoles.ARCHITECT.displayName, "sa", "a"), Role("B", "sb", "b")))
         )
-        val interactor = RolesStateInteractor(repo)
+        val flow = RolesStateFlow(repo)
+        val interactor = RolesStateInteractor(flow)
         interactor.load()
         interactor.deleteRole()
         assertEquals(2, repo.data.roles.size)
@@ -61,7 +65,8 @@ class RolesStateInteractorTest {
     @Test
     fun startAndFinishCreateRoleToggleFlag() = runBlocking {
         val repo = FakeRolesRepository(Roles(0, emptyList()))
-        val interactor = RolesStateInteractor(repo)
+        val flow = RolesStateFlow(repo)
+        val interactor = RolesStateInteractor(flow)
         interactor.startCreateRole()
         assertEquals(true, interactor.creatingRole)
         interactor.finishCreateRole()


### PR DESCRIPTION
## Summary
- Introduce RolesStateFlow to own roles data
- Update RolesStateInteractor to modify RolesStateFlow
- Combine chat and roles flows in StateProvider and adjust navigation

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68976cd86ce88320a7913e53a4bebc0c