### PR TITLE
refactor: reuse list row component and confirm chat deletion

### DIFF
--- a/src/main/kotlin/io/qent/sona/Strings.kt
+++ b/src/main/kotlin/io/qent/sona/Strings.kt
@@ -67,6 +67,7 @@ object Strings {
     val serversActionDescription: String get() = bundle.getString("serversActionDescription")
     val addRole: String get() = bundle.getString("addRole")
     val deleteRoleQuestion: String get() = bundle.getString("deleteRoleQuestion")
+    val deleteChatQuestion: String get() = bundle.getString("deleteChatQuestion")
     val shortDescription: String get() = bundle.getString("shortDescription")
 }
 

--- a/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
@@ -20,9 +20,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.input.pointer.pointerMoveFilter
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
@@ -30,7 +27,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.intellij.openapi.util.IconLoader
 import com.intellij.openapi.project.Project
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.markdownComponents
@@ -38,16 +34,13 @@ import com.mikepenz.markdown.model.rememberMarkdownState
 import io.qent.sona.Strings
 import io.qent.sona.core.state.State.ChatState
 import io.qent.sona.core.state.UiMessage
-import io.qent.sona.PluginStateFlow
+import io.qent.sona.ui.common.loadIcon
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
-import java.awt.image.BufferedImage
-
 import io.qent.sona.ui.SonaTheme
 import dev.langchain4j.agent.tool.ToolExecutionRequest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import javax.swing.Icon
 
 @Composable
 fun ChatPanel(project: Project, state: ChatState) {
@@ -65,7 +58,6 @@ fun ChatPanel(project: Project, state: ChatState) {
         ChatInput(state)
     }
 }
-
 @Composable
 private fun Messages(project: Project, state: ChatState, modifier: Modifier = Modifier) {
     val listState = rememberLazyListState()
@@ -309,10 +301,9 @@ fun ToolMessageBubble(
             )
         }
     }
-}
-
-@Composable
-private fun AnimatedDots(color: Color) {
+  }
+  @Composable
+  private fun AnimatedDots(color: Color) {
     var dots by remember { mutableStateOf(0) }
     LaunchedEffect(Unit) {
         while (true) {
@@ -321,10 +312,9 @@ private fun AnimatedDots(color: Color) {
         }
     }
     Text(".".repeat(dots), color = color, fontSize = 10.sp, fontFamily = FontFamily.Monospace)
-}
-
-@Composable
-private fun ToolRequests(requests: List<ToolExecutionRequest>) {
+  }
+  @Composable
+  private fun ToolRequests(requests: List<ToolExecutionRequest>) {
     Column(
         Modifier
             .fillMaxWidth()
@@ -336,9 +326,8 @@ private fun ToolRequests(requests: List<ToolExecutionRequest>) {
         }
     }
 }
-
-@Composable
-private fun ToolPermissionButtons(
+  @Composable
+  private fun ToolPermissionButtons(
     onOk: () -> Unit,
     onAlways: () -> Unit,
     onCancel: () -> Unit,
@@ -364,17 +353,3 @@ private fun ToolPermissionButtons(
     }
 }
 
-@Composable
-fun loadIcon(path: String): Painter {
-    val icon = IconLoader.getIcon(path, PluginStateFlow::class.java)
-    val bufferedImage = iconToImage(icon)
-    return BitmapPainter(bufferedImage.toComposeImageBitmap())
-}
-
-fun iconToImage(icon: Icon): BufferedImage {
-    val image = BufferedImage(icon.iconWidth, icon.iconHeight, BufferedImage.TYPE_INT_ARGB)
-    val g = image.createGraphics()
-    icon.paintIcon(null, g, 0, 0)
-    g.dispose()
-    return image
-}

--- a/src/main/kotlin/io/qent/sona/ui/common/IconUtils.kt
+++ b/src/main/kotlin/io/qent/sona/ui/common/IconUtils.kt
@@ -1,0 +1,25 @@
+package io.qent.sona.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import com.intellij.openapi.util.IconLoader
+import io.qent.sona.PluginStateFlow
+import java.awt.image.BufferedImage
+import javax.swing.Icon
+
+@Composable
+fun loadIcon(path: String): Painter {
+    val icon = IconLoader.getIcon(path, PluginStateFlow::class.java)
+    return remember(icon) { BitmapPainter(iconToImage(icon).toComposeImageBitmap()) }
+}
+
+private fun iconToImage(icon: Icon): BufferedImage {
+    val image = BufferedImage(icon.iconWidth, icon.iconHeight, BufferedImage.TYPE_INT_ARGB)
+    val g = image.createGraphics()
+    icon.paintIcon(null, g, 0, 0)
+    g.dispose()
+    return image
+}

--- a/src/main/kotlin/io/qent/sona/ui/common/TwoLineItem.kt
+++ b/src/main/kotlin/io/qent/sona/ui/common/TwoLineItem.kt
@@ -1,0 +1,67 @@
+package io.qent.sona.ui.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.qent.sona.ui.SonaTheme
+import org.jetbrains.jewel.ui.component.Text
+
+@Composable
+fun TwoLineItem(
+    title: String,
+    subtitle: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    onEdit: (() -> Unit)? = null,
+    onDelete: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (selected) SonaTheme.colors.UserBubble else SonaTheme.colors.AiBubble)
+            .clickable { onClick() }
+            .padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(title, fontWeight = FontWeight.Bold, color = SonaTheme.colors.AiText, maxLines = 1)
+            Text(subtitle, color = SonaTheme.colors.BackgroundText, fontSize = 12.sp)
+        }
+        onEdit?.let {
+            Image(
+                painter = loadIcon("/icons/edit.svg"),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(SonaTheme.colors.AiText),
+                modifier = Modifier
+                    .size(16.dp)
+                    .clickable(onClick = it)
+            )
+        }
+        if (onEdit != null && onDelete != null) {
+            Spacer(Modifier.width(8.dp))
+        }
+        onDelete?.let {
+            Image(
+                painter = loadIcon("/icons/trash.svg"),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(SonaTheme.colors.AiText),
+                modifier = Modifier
+                    .size(16.dp)
+                    .clickable(onClick = it)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/io/qent/sona/ui/history/ChatListPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/history/ChatListPanel.kt
@@ -1,25 +1,22 @@
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.qent.sona.Strings
 import io.qent.sona.core.state.State.ChatListState
 import io.qent.sona.ui.SonaTheme
-import org.jetbrains.jewel.ui.component.ActionButton
+import io.qent.sona.ui.common.DeleteConfirmationDialog
+import io.qent.sona.ui.common.TwoLineItem
 import org.jetbrains.jewel.ui.component.Text
 import java.text.SimpleDateFormat
 import java.util.*
 
 @Composable
 fun ChatListPanel(state: ChatListState) {
+    var deleteId by remember { mutableStateOf<String?>(null) }
     val listState = rememberLazyListState()
     Column(
         Modifier
@@ -27,11 +24,11 @@ fun ChatListPanel(state: ChatListState) {
             .background(SonaTheme.colors.Background)
             .padding(8.dp)
     ) {
-            Text(
-                Strings.history,
-                modifier = Modifier.padding(top = 8.dp, bottom = 12.dp),
-                style = SonaTheme.markdownTypography.h5
-            )
+        Text(
+            Strings.history,
+            modifier = Modifier.padding(top = 8.dp, bottom = 12.dp),
+            style = SonaTheme.markdownTypography.h5
+        )
         LazyColumn(
             state = listState,
             modifier = Modifier
@@ -40,40 +37,25 @@ fun ChatListPanel(state: ChatListState) {
         ) {
             items(state.chats.size) { idx ->
                 val chat = state.chats[idx]
-                Box(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(SonaTheme.colors.AiBubble)
-                        .clickable(onClick = { state.onOpenChat(chat.id) })
-                ) {
-                    ActionButton(
-                        onClick = { state.onDeleteChat(chat.id) },
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(horizontal = 6.dp)
-                            .padding(top = 8.dp)
-                    ) {
-                        Text("\uD83D\uDDD1")
-                    }
-
-                    Column(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(12.dp)
-                    ) {
-                        Text(chat.firstMessage, maxLines = 1, color = SonaTheme.colors.AiText)
-                        Spacer(modifier = Modifier.height(6.dp))
-                        val date = SimpleDateFormat("yyyy-MM-dd HH:mm").format(Date(chat.createdAt))
-                        Text(
-                            text = "$date · ${chat.messages} ${Strings.messages}",
-                            fontSize = 12.sp,
-                            color = SonaTheme.colors.Placeholder
-                        )
-                    }
-                }
+                val date = SimpleDateFormat("yyyy-MM-dd HH:mm").format(Date(chat.createdAt))
+                TwoLineItem(
+                    title = chat.firstMessage,
+                    subtitle = "$date · ${chat.messages} ${Strings.messages}",
+                    selected = false,
+                    onClick = { state.onOpenChat(chat.id) },
+                    onDelete = { deleteId = chat.id }
+                )
             }
         }
+    }
+    deleteId?.let { id ->
+        DeleteConfirmationDialog(
+            text = Strings.deleteChatQuestion,
+            onConfirm = {
+                state.onDeleteChat(id)
+                deleteId = null
+            },
+            onCancel = { deleteId = null }
+        )
     }
 }

--- a/src/main/kotlin/io/qent/sona/ui/presets/PresetsPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/presets/PresetsPanel.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -31,6 +30,7 @@ import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextField
+import io.qent.sona.ui.common.TwoLineItem
 
 @Composable
 fun PresetsPanel(state: State.PresetsListState) {
@@ -48,28 +48,14 @@ fun PresetsPanel(state: State.PresetsListState) {
             contentPadding = PaddingValues(bottom = 56.dp)
         ) {
             itemsIndexed(state.presets) { idx, preset ->
-                Row(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(if (idx == state.currentIndex) SonaTheme.colors.UserBubble else SonaTheme.colors.AiBubble)
-                        .clickable { state.onSelectPreset(idx) }
-                        .padding(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(Modifier.weight(1f)) {
-                        Text(preset.name, fontWeight = FontWeight.Bold, color = SonaTheme.colors.AiText)
-                        Text(
-                            "${preset.provider.name} / ${preset.model}",
-                            color = SonaTheme.colors.BackgroundText,
-                            fontSize = 12.sp
-                        )
-                    }
-                    ActionButton(onClick = { state.onEditPreset(idx) }) { Text("✏") }
-                    Spacer(Modifier.width(8.dp))
-                    ActionButton(onClick = { deleteIndex = idx }) { Text("\uD83D\uDDD1") }
-                }
+                TwoLineItem(
+                    title = preset.name,
+                    subtitle = "${preset.provider.name} / ${preset.model}",
+                    selected = idx == state.currentIndex,
+                    onClick = { state.onSelectPreset(idx) },
+                    onEdit = { state.onEditPreset(idx) },
+                    onDelete = { deleteIndex = idx }
+                )
             }
         }
         Box(

--- a/src/main/kotlin/io/qent/sona/ui/roles/RolesPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/roles/RolesPanel.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.draw.clip
@@ -25,6 +24,7 @@ import io.qent.sona.ui.SonaTheme
 import io.qent.sona.ui.common.DeleteConfirmationDialog
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Text
+import io.qent.sona.ui.common.TwoLineItem
 import org.jetbrains.jewel.ui.component.TextArea
 import org.jetbrains.jewel.ui.component.TextField
 
@@ -44,27 +44,14 @@ fun RolesListPanel(state: State.RolesListState) {
             contentPadding = PaddingValues(bottom = 56.dp)
         ) {
             itemsIndexed(state.roles) { idx, role ->
-                Row(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(if (idx == state.currentIndex) SonaTheme.colors.UserBubble else SonaTheme.colors.AiBubble)
-                        .clickable { state.onSelectRole(idx) }
-                        .padding(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(Modifier.weight(1f)) {
-                        Text(role.name, fontWeight = FontWeight.Bold, color = SonaTheme.colors.AiText)
-                        Text(role.short, color = SonaTheme.colors.BackgroundText, fontSize = 12.sp)
-                    }
-                    ActionButton(onClick = { state.onEditRole(idx) }) { Text("✏") }
-                    Spacer(Modifier.width(8.dp))
-                    ActionButton(
-                        onClick = { deleteIndex = idx },
-                        enabled = role.name !in DefaultRoles.NAMES
-                    ) { Text("\uD83D\uDDD1") }
-                }
+                TwoLineItem(
+                    title = role.name,
+                    subtitle = role.short,
+                    selected = idx == state.currentIndex,
+                    onClick = { state.onSelectRole(idx) },
+                    onEdit = { state.onEditRole(idx) },
+                    onDelete = if (role.name !in DefaultRoles.NAMES) { { deleteIndex = idx } } else null
+                )
             }
         }
         Box(

--- a/src/main/resources/icons/edit.svg
+++ b/src/main/resources/icons/edit.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20h9"/>
+  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>
+</svg>

--- a/src/main/resources/messages/Strings.properties
+++ b/src/main/resources/messages/Strings.properties
@@ -59,4 +59,5 @@ addPreset=Add preset
 deletePresetQuestion=Delete preset?
 addRole=Add role
 deleteRoleQuestion=Delete role?
+deleteChatQuestion=Delete chat?
 shortDescription=Short description

--- a/src/main/resources/messages/Strings_de.properties
+++ b/src/main/resources/messages/Strings_de.properties
@@ -59,4 +59,5 @@ addPreset=Voreinstellung hinzufügen
 deletePresetQuestion=Voreinstellung löschen?
 addRole=Rolle hinzufügen
 deleteRoleQuestion=Rolle löschen?
+deleteChatQuestion=Chat löschen?
 shortDescription=Kurze Beschreibung

--- a/src/main/resources/messages/Strings_fr.properties
+++ b/src/main/resources/messages/Strings_fr.properties
@@ -59,4 +59,5 @@ addPreset=Ajouter un préréglage
 deletePresetQuestion=Supprimer le préréglage ?
 addRole=Ajouter un rôle
 deleteRoleQuestion=Supprimer le rôle ?
+deleteChatQuestion=Supprimer le chat ?
 shortDescription=Brève description

--- a/src/main/resources/messages/Strings_ru.properties
+++ b/src/main/resources/messages/Strings_ru.properties
@@ -59,4 +59,5 @@ addPreset=добавить пресет
 deletePresetQuestion=Удалить пресет?
 addRole=добавить роль
 deleteRoleQuestion=Удалить роль?
+deleteChatQuestion=Удалить чат?
 shortDescription=Краткое описание

--- a/src/main/resources/messages/Strings_zh.properties
+++ b/src/main/resources/messages/Strings_zh.properties
@@ -59,4 +59,5 @@ addPreset=添加预设
 deletePresetQuestion=删除预设？
 addRole=添加角色
 deleteRoleQuestion=删除角色？
+deleteChatQuestion=删除聊天？
 shortDescription=简短描述


### PR DESCRIPTION
## Summary
- extract reusable `TwoLineItem` composable with optional edit and delete icons
- apply unified row in chat history, roles and presets lists
- prompt for chat deletion confirmation and add edit icon resource

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689794af48f08320b27eae452e83ffb3