### PR TITLE
Refactor presets state handling to dedicated StateFlow

### DIFF
--- a/core/src/main/kotlin/io/qent/sona/core/state/EditRoleStateInteractor.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/EditRoleStateInteractor.kt
@@ -1,8 +1,9 @@
 package io.qent.sona.core.state
 
 import io.qent.sona.core.roles.Role
+import io.qent.sona.core.roles.Roles
 
-class EditRoleStateInteractor(private val listInteractor: RolesListStateInteractor) {
+class EditRoleStateInteractor(private val flow: RolesStateFlow) {
     private var editingIndex: Int? = null
     var role: Role = Role("", "", "")
         private set
@@ -17,14 +18,19 @@ class EditRoleStateInteractor(private val listInteractor: RolesListStateInteract
 
     fun startEdit(idx: Int) {
         editingIndex = idx
-        role = listInteractor.roles.roles[idx]
+        role = flow.value.roles[idx]
     }
 
     suspend fun save(r: Role) {
+        val current = flow.value
         if (editingIndex == null) {
-            listInteractor.addRole(r)
+            flow.save(Roles(active = current.roles.size, roles = current.roles + r))
         } else {
-            listInteractor.updateRole(editingIndex!!, r)
+            val list = current.roles.toMutableList()
+            if (editingIndex!! in list.indices) {
+                list[editingIndex!!] = r
+                flow.save(current.copy(roles = list))
+            }
         }
     }
 }

--- a/core/src/main/kotlin/io/qent/sona/core/state/PresetsStateFlow.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/PresetsStateFlow.kt
@@ -1,0 +1,24 @@
+package io.qent.sona.core.state
+
+import io.qent.sona.core.presets.Presets
+import io.qent.sona.core.presets.PresetsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.FlowCollector
+
+class PresetsStateFlow(private val repository: PresetsRepository) : StateFlow<Presets> {
+    private val _presets = MutableStateFlow(Presets(0, emptyList()))
+
+    override val replayCache: List<Presets> get() = _presets.replayCache
+    override val value: Presets get() = _presets.value
+    override suspend fun collect(collector: FlowCollector<Presets>) = _presets.collect(collector)
+
+    suspend fun load() {
+        _presets.value = repository.load()
+    }
+
+    suspend fun save(presets: Presets) {
+        _presets.value = presets
+        repository.save(presets)
+    }
+}

--- a/core/src/test/kotlin/io/qent/sona/core/state/PresetsListStateInteractorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/state/PresetsListStateInteractorTest.kt
@@ -4,6 +4,7 @@ import io.qent.sona.core.presets.LlmProvider
 import io.qent.sona.core.presets.Preset
 import io.qent.sona.core.presets.Presets
 import io.qent.sona.core.presets.PresetsRepository
+import io.qent.sona.core.state.PresetsStateFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -18,7 +19,8 @@ class PresetsListStateInteractorTest {
     fun addPresetUpdatesRepository() = runBlocking {
         val provider = LlmProvider("p", "e", emptyList())
         val repo = FakePresetsRepository(Presets(0, emptyList()))
-        val interactor = PresetsListStateInteractor(repo)
+        val flow = PresetsStateFlow(repo)
+        val interactor = PresetsListStateInteractor(flow)
         interactor.load()
         interactor.addPreset(Preset("n", provider, "e", "m", "k"))
         assertEquals(1, repo.data.presets.size)
@@ -31,7 +33,8 @@ class PresetsListStateInteractorTest {
         val p1 = Preset("a", provider, "e", "m", "k")
         val p2 = Preset("b", provider, "e", "m", "k")
         val repo = FakePresetsRepository(Presets(0, listOf(p1, p2)))
-        val interactor = PresetsListStateInteractor(repo)
+        val flow = PresetsStateFlow(repo)
+        val interactor = PresetsListStateInteractor(flow)
         interactor.load()
         interactor.selectPreset(1)
         assertEquals(1, repo.data.active)
@@ -41,7 +44,8 @@ class PresetsListStateInteractorTest {
     fun updatePresetUpdatesRepository() = runBlocking {
         val provider = LlmProvider("p", "e", emptyList())
         val repo = FakePresetsRepository(Presets(0, listOf(Preset("a", provider, "e", "m", "k"))))
-        val interactor = PresetsListStateInteractor(repo)
+        val flow = PresetsStateFlow(repo)
+        val interactor = PresetsListStateInteractor(flow)
         interactor.load()
         interactor.updatePreset(0, Preset("a", provider, "e", "m2", "k"))
         assertEquals("m2", repo.data.presets[0].model)
@@ -53,7 +57,8 @@ class PresetsListStateInteractorTest {
         val repo = FakePresetsRepository(
             Presets(0, listOf(Preset("a", provider, "e", "m", "k"), Preset("b", provider, "e", "m", "k")))
         )
-        val interactor = PresetsListStateInteractor(repo)
+        val flow = PresetsStateFlow(repo)
+        val interactor = PresetsListStateInteractor(flow)
         interactor.load()
         interactor.deletePreset(0)
         assertEquals(1, repo.data.presets.size)

--- a/core/src/test/kotlin/io/qent/sona/core/state/RolesListStateInteractorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/state/RolesListStateInteractorTest.kt
@@ -66,9 +66,8 @@ class EditRoleStateInteractorTest {
     fun startEditLoadsRole() = runBlocking {
         val repo = FakeRolesRepository(Roles(0, listOf(Role("A", "sa", "a"), Role("B", "sb", "b"))))
         val flow = RolesStateFlow(repo)
-        val listInteractor = RolesListStateInteractor(flow)
-        listInteractor.load()
-        val editInteractor = EditRoleStateInteractor(listInteractor)
+        flow.load()
+        val editInteractor = EditRoleStateInteractor(flow)
         editInteractor.startEdit(1)
         assertEquals("B", editInteractor.role.name)
     }
@@ -77,9 +76,8 @@ class EditRoleStateInteractorTest {
     fun saveUpdatesListInteractor() = runBlocking {
         val repo = FakeRolesRepository(Roles(0, listOf(Role("A", "sa", "a"))))
         val flow = RolesStateFlow(repo)
-        val listInteractor = RolesListStateInteractor(flow)
-        listInteractor.load()
-        val editInteractor = EditRoleStateInteractor(listInteractor)
+        flow.load()
+        val editInteractor = EditRoleStateInteractor(flow)
         editInteractor.startCreate()
         editInteractor.save(Role("B", "sb", "b"))
         assertEquals(2, repo.data.roles.size)


### PR DESCRIPTION
## Summary
- Introduce `PresetsStateFlow` backed by `MutableStateFlow`
- Update preset and role interactors to use state flows directly
- Combine chat, roles, and presets flows in `StateProvider`
- Listen to preset changes for chat and preset panels

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6897a81d7954832098551c53811e3723