### PR TITLE
refactor: extract chat controller and state flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
   descriptions.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
   environment (OS, IDE, Java, Python, Node.js, file extension statistics, build systems) and is prepended to every LLM request.
-- ChatFlow leverages langchain4j `AiService` and `TokenStream` to emit partial responses and tool events via streaming callbacks.
+- ChatController leverages langchain4j `AiService` and `TokenStream` to emit partial responses and tool events via streaming callbacks.
 - AI messages show a gear icon that toggles visibility of requested tools. Tool outputs stream into a terminal-style bubble with animated dots until completion.
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.
@@ -46,9 +46,7 @@ IDE theme changes.
 
 ## Current structure
 
-- **core module** – contains `ChatFlow`, a thin `StateProvider` facade, `StateFactory` and domain interactors (`ChatStateInteractor`, `RolesListStateInteractor`, `EditRoleStateInteractor`, `PresetsListStateInteractor`, `EditPresetStateInteractor`, `ServersStateInteractor`). `ChatFlow` is a
-  `MutableStateFlow` based `Flow` that manages the conversation with the model
-  and keeps track of token usage while the interactors handle domain logic.
+- **core module** – contains `ChatController`, `ChatStateFlow`, a thin `StateProvider` facade, `StateFactory` and domain interactors (`ChatStateInteractor`, `RolesListStateInteractor`, `EditRoleStateInteractor`, `PresetsListStateInteractor`, `EditPresetStateInteractor`, `ServersStateInteractor`). `ChatStateFlow` emits the current chat while `ChatController` manages the conversation with the model and keeps track of token usage while the interactors handle domain logic.
 - **Plugin module** – provides IntelliJ implementations of the repositories,
   the Compose UI and `PluginStateFlow`, a project service exposing
   `StateFlow<State>` from `StateProvider`.
@@ -68,7 +66,7 @@ variables, transport, URL, working directory, request headers and an optional
 these servers require the same user permission prompts as local tools. Server enablement and
 disabled tools are stored in `sona.json`; only servers marked as enabled reconnect
 automatically on restart.
-`ChatFlow` depends only on the `Tools` interface and receives the decorator from `StateProvider`.
+`ChatController` receives a `Tools` decorator from `StateProvider` via its injected `ChatAgentFactory`.
 
 Whenever you extend the logic make sure the flow of state remains unidirectional
 and that the core module stays free from IntelliJ SDK imports.

--- a/README.md
+++ b/README.md
@@ -165,9 +165,10 @@ The project is split into two modules:
 ### Core module
 
 The `core` module defines a small MVI style state container. The main
-entry point is `ChatFlow`, a `Flow<Chat>` backed by a `MutableStateFlow`.
-It orchestrates message exchange with the language model and exposes the
-current conversation state:
+entry point is a pair of `ChatController` and `ChatStateFlow`. The
+`ChatStateFlow` is a `Flow<Chat>` that holds the current conversation,
+while `ChatController` orchestrates message exchange with the language
+model:
 
 ```
 data class Chat(
@@ -179,9 +180,9 @@ data class Chat(
 )
 ```
 
-`StateProvider` consumes `ChatFlow` and maps it to a higher level
-`State` model used by the UI. Both `ChatFlow` and `StateProvider`
-operate purely on Kotlin flows without any IntelliJ types.
+`StateProvider` consumes `ChatStateFlow` and maps it to a higher level
+`State` model used by the UI. Both `ChatController` and
+`StateProvider` operate purely on Kotlin flows without any IntelliJ types.
 
 `tokenUsage` represents the cumulative input, output and cached tokens
 spent for all AI responses in the chat. Each AI message also
@@ -218,7 +219,7 @@ automatically switches between light and dark palettes.
 
 All state propagation relies on Kotlin `Flow`/`StateFlow`:
 
-* `ChatFlow` implements `Flow<Chat>` and exposes conversation updates.
+* `ChatStateFlow` exposes conversation updates as `Flow<Chat>`.
 * `StateProvider` provides a `StateFlow<State>` for the UI.
 * `PluginStateFlow` exposes the same `StateFlow` as a project level
   service.

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatRepositoryChatMemoryStore.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatRepositoryChatMemoryStore.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.runBlocking
 
 /**
  * ChatMemory backed by [ChatRepository]. It loads existing messages
- * synchronously and stores new ones only in memory. ChatFlow persists
+ * synchronously and stores new ones only in memory. ChatController persists
  * messages explicitly so this memory primarily serves the AI service
  * during a request.
  */

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatSession.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatSession.kt
@@ -1,0 +1,12 @@
+package io.qent.sona.core.chat
+
+/**
+ * Represents chat side effects that operate on [ChatStateFlow].
+ */
+interface ChatSession {
+    suspend fun send(text: String)
+    fun stop()
+    suspend fun deleteFrom(idx: Int)
+    fun toggleAutoApproveTools()
+}
+


### PR DESCRIPTION
## Summary
- decouple chat operations from flow by introducing ChatController and ChatSession
- move chat state and tool permission handling to StateProvider and ChatStateFlow
- update docs and tests for new chat architecture

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68985b2e35888320b240bc241733253e