### PR TITLE
feat: add logging facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ message and for the entire conversation. It also displays how much of the
 model's context window is currently filled based on the active preset.
 
 The settings screen is split into two sections. **Plugin Settings** contains the
-original **Ignore HTTPS errors** option, an **Enable plugin logging** flag and a
-field for **LLM API retries** that controls how many times failed requests are
+original **Ignore HTTPS errors** option, an **Enable plugin logging** flag that writes
+debug messages to the IDE log, and a field for **LLM API retries** that controls how many times failed requests are
 retried with exponential backoff. The new **Anthropic Settings** section adds
 checkboxes to cache system prompts and tool descriptions when sending requests
 to Anthropic models.

--- a/core/src/main/kotlin/io/qent/sona/core/Logger.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/Logger.kt
@@ -1,0 +1,15 @@
+package io.qent.sona.core
+
+/**
+ * Simple logging facade used by the core module so the logic stays free of
+ * any IntelliJ SDK dependencies. The actual logging implementation is
+ * provided by the consumer of the core module.
+ */
+interface Logger {
+    fun log(message: String)
+
+    object NoOp : Logger {
+        override fun log(message: String) {}
+    }
+}
+

--- a/core/src/main/kotlin/io/qent/sona/core/chat/PermissionedToolExecutor.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/PermissionedToolExecutor.kt
@@ -4,6 +4,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest
 import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ToolExecutionResultMessage
 import dev.langchain4j.service.tool.ToolExecutor
+import io.qent.sona.core.Logger
 import io.qent.sona.core.model.TokenUsageInfo
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.runBlocking
@@ -15,7 +16,7 @@ data class ToolDecision(val allow: Boolean, val always: Boolean)
 class PermissionedToolExecutor(
     private val chatStateFlow: ChatStateFlow,
     private val chatRepository: ChatRepository,
-    private val log: (String) -> Unit = {},
+    private val log: Logger = Logger.NoOp,
 ) {
 
     private val currentChatState get() = chatStateFlow.currentState
@@ -23,10 +24,10 @@ class PermissionedToolExecutor(
     private var toolContinuation: CancellableContinuation<ToolDecision>? = null
 
     fun resolveToolPermission(allow: Boolean, always: Boolean) {
-        log("resolveToolPermission: allow=$allow always=$always")
+        log.log("resolveToolPermission: allow=$allow always=$always")
         toolContinuation?.resume(ToolDecision(allow, always))
         toolContinuation = null
-        log("emit: tool request = null")
+        log.log("emit: tool request = null")
         chatStateFlow.emit(currentChatState.copy(toolRequest = null, requestInProgress = true))
     }
 
@@ -36,7 +37,7 @@ class PermissionedToolExecutor(
         name: String,
         run: (ToolExecutionRequest) -> String
     ) = ToolExecutor { request, memoryId ->
-        log("tool execute request: ${request.name()}")
+        log.log("tool execute request: ${request.name()}")
         runBlocking {
             // fix empty lastAiMessage tools
             val messages = currentChatState.messages.toMutableList()
@@ -52,28 +53,28 @@ class PermissionedToolExecutor(
                     lastAiMessage.model,
                     lastAiMessage.tokenUsage
                 )
-                log("emit: fixed message with tools request")
+                log.log("emit: fixed message with tools request")
                 chatStateFlow.emit(currentChatState.copy(messages = messages))
             }
         }
 
         val decision = runBlocking {
             if (currentChatState.autoApproveTools || chatRepository.isToolAllowed(chatId, name)) {
-                log("autoApproveTools = ${currentChatState.autoApproveTools} or tool allowed at chat")
+                log.log("autoApproveTools = ${currentChatState.autoApproveTools} or tool allowed at chat")
                 ToolDecision(true, false)
             } else {
                 requestToolPermission(name)
             }
         }
-        log("tool decision: allow=${decision.allow} always=${decision.always}")
+        log.log("tool decision: allow=${decision.allow} always=${decision.always}")
         if (decision.always) {
             runBlocking {
-                log("add allowed tool")
+                log.log("add allowed tool")
                 chatRepository.addAllowedTool(chatId, name)
             }
         }
         if (decision.allow) {
-            log("emit: tool placeholder")
+            log.log("emit: tool placeholder")
             chatStateFlow.emit(
                 currentChatState.copy(
                     messages = currentChatState.messages + ChatRepositoryMessage(
@@ -90,10 +91,10 @@ class PermissionedToolExecutor(
     }
 
     private suspend fun requestToolPermission(toolName: String): ToolDecision {
-        log("requestToolPermission: $toolName")
+        log.log("requestToolPermission: $toolName")
         return suspendCancellableCoroutine { cont ->
             toolContinuation = cont
-            log("emit: tool request = $toolName")
+            log.log("emit: tool request = $toolName")
             chatStateFlow.emit(
                 currentChatState.copy(
                     toolRequest = toolName,

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpConnectionManager.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpConnectionManager.kt
@@ -9,11 +9,13 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import io.qent.sona.core.Logger
 import java.io.File
 
 class McpConnectionManager(
     private val repository: McpServersRepository,
-    scope: CoroutineScope
+    scope: CoroutineScope,
+    private val log: Logger = Logger.NoOp
 ) {
     private val scope = scope + SupervisorJob() + Dispatchers.IO
     private val clients = mutableMapOf<String, McpClient>()
@@ -94,7 +96,7 @@ class McpConnectionManager(
                         disabledTools = disabled[config.name] ?: emptySet(),
                     )
                 )
-                println("Failed to connect to MCP server ${config.name}: ${it.message}")
+                log.log("Failed to connect to MCP server ${config.name}: ${it.message}")
             }
         }
     }
@@ -208,7 +210,7 @@ class McpConnectionManager(
                     .build()
             }
             else -> {
-                println("Unsupported MCP transport: ${config.transport}")
+                log.log("Unsupported MCP transport: ${config.transport}")
                 return null
             }
         }

--- a/src/main/kotlin/io/qent/sona/IdeaLogger.kt
+++ b/src/main/kotlin/io/qent/sona/IdeaLogger.kt
@@ -1,0 +1,15 @@
+package io.qent.sona
+
+import com.intellij.openapi.diagnostic.Logger
+import io.qent.sona.core.Logger as CoreLogger
+
+/**
+ * Intellij-based logger implementation for the core logging facade.
+ */
+object IdeaLogger : CoreLogger {
+    private val logger = Logger.getInstance("Sona")
+    override fun log(message: String) {
+        logger.info(message)
+    }
+}
+

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -15,6 +15,7 @@ import io.qent.sona.core.presets.Presets
 import io.qent.sona.core.state.State
 import io.qent.sona.core.state.StateProvider
 import io.qent.sona.core.state.UiMessage
+import io.qent.sona.IdeaLogger
 import io.qent.sona.repositories.*
 import io.qent.sona.tools.PluginExternalTools
 import kotlinx.coroutines.CoroutineScope
@@ -172,6 +173,7 @@ class PluginStateFlow(private val project: Project) : Flow<State>, Disposable {
             editConfig = { project.service<PluginMcpServersRepository>().openConfig() },
             scope = scope,
             systemMessages = createSystemMessages(),
+            logger = IdeaLogger,
         )
 
         stateProvider.state.onEach {


### PR DESCRIPTION
## Summary
- introduce `Logger` interface in core to decouple logging from IntelliJ
- implement `IdeaLogger` using IntelliJ's logging API and wire into `StateProvider`
- document plugin logging behaviour in README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689a3d840638832085da816a21558694