### PR TITLE
Add memory MCP server and instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,9 @@ variables, transport, URL, working directory, request headers and an optional
 these servers require the same user permission prompts as local tools. Server enablement and
 disabled tools are stored in `sona.json`; only servers marked as enabled reconnect
 automatically on restart.
+The plugin preconfigures two servers: `@jetbrains/mcp-proxy` and `memory`. The
+`memory` server runs `@modelcontextprotocol/server-memory` via `npx` and stores
+its data in `sona_memory.json` at the project root.
 When updating the configuration, merge new values into `sona.json` to preserve any
 user-provided fields instead of overwriting the file.
 `ChatController` receives a `Tools` decorator from `StateProvider` via its injected `ChatAgentFactory`.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ checking typical installation locations for the current operating system before 
 Currently `transport` may be `stdio` or `http`. Every server runs in its own coroutine so a failure does
 not affect the plugin. Tools provided by MCP servers require the same user confirmation as local tools.
 
+Sona ships with two predefined servers: `@jetbrains/mcp-proxy` and `memory`. The
+`memory` server uses `@modelcontextprotocol/server-memory` via `npx` and stores
+its state in `sona_memory.json` at the project root. When this server is enabled,
+its usage instructions from `prompts/memory_instructions.md` are appended to the
+system messages sent with each request.
+
 The tool window includes a **Servers** action listing all configured MCP servers. Each server is shown as a card
 with a coloured status indicator – grey for disabled, red when a connection fails, yellow while connecting and
 green once connected and exposing tools. Clicking a card toggles the server on or off. A refresh button above

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpConnectionManager.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpConnectionManager.kt
@@ -191,6 +191,12 @@ class McpConnectionManager(
 
 
     private fun createClient(config: McpServerConfig): DefaultMcpClient? {
+        config.env?.get("MEMORY_FILE_PATH")?.let { path ->
+            runCatching {
+                val file = File(path)
+                if (!file.exists()) file.createNewFile()
+            }
+        }
         val transport = when (config.transport.lowercase()) {
             "stdio" -> {
                 val cmd = buildList {

--- a/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
@@ -11,6 +11,7 @@ import java.io.File
 import kotlinx.coroutines.runBlocking
 
 private val JETBRAINS_MCP_ARGS = listOf("-y", "@jetbrains/mcp-proxy")
+private val MEMORY_MCP_ARGS = listOf("-y", "@modelcontextprotocol/server-memory")
 
 @Service(Service.Level.PROJECT)
 class PluginMcpServersRepository(private val project: Project) : McpServersRepository {
@@ -38,6 +39,18 @@ class PluginMcpServersRepository(private val project: Project) : McpServersRepos
                     name = "@jetbrains/mcp-proxy",
                     command = "npx",
                     args = JETBRAINS_MCP_ARGS,
+                    transport = "stdio"
+                )
+            )
+        }
+
+        if (result.none { it.args?.joinToString() == MEMORY_MCP_ARGS.joinToString() }) {
+            result.add(
+                McpServerConfig(
+                    name = "memory",
+                    command = "npx",
+                    args = MEMORY_MCP_ARGS,
+                    env = mapOf("MEMORY_FILE_PATH" to File(root, "sona_memory.json").absolutePath),
                     transport = "stdio"
                 )
             )

--- a/src/main/resources/prompts/memory_instructions.md
+++ b/src/main/resources/prompts/memory_instructions.md
@@ -1,0 +1,23 @@
+# Memory MCP Server Usage
+
+You can persist long-term knowledge about this software project using the `memory` MCP server.
+
+The server configuration:
+
+```
+"memory": {
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-memory"],
+  "env": { "MEMORY_FILE_PATH": "/project_root/sona_memory.json" }
+}
+```
+
+Before writing, verify that the file at `MEMORY_FILE_PATH` exists and create it if missing. This path points to `sona_memory.json` in the project root.
+
+Use the tools exposed by this server to store and retrieve key details about the software-development project:
+- architecture and design decisions;
+- plans, milestones and outstanding tasks across planning, implementation, testing and release stages;
+- important discussions, links and credentials (only after explicit user authorisation);
+- lessons learned that will help future contributors.
+
+Keep entries concise, relevant and free of unnecessary sensitive data.


### PR DESCRIPTION
## Summary
- preconfigure `memory` MCP server pointing to `sona_memory.json`
- include memory instructions prompt when server is enabled
- document new memory server and prompt

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_689b5aa625648320b26ddd8624264661