### PR TITLE
Add directory listing tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@
   not persisted.
 - A tool is available to switch the active role by name using the roles' short
   descriptions.
+- A tool lists files and directories for a given path, appending "/" to directory names and
+  including the first-level contents of each directory.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
   environment (OS, IDE, Java, Python, Node.js, file extension statistics, build systems) and is prepended to every LLM request.
 - Any `.md` files in `src/main/resources/prompts` are read at startup and their contents are appended as additional system messages.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ you switch to a different chat.
 
 Tool calls referenced by the model are hidden behind a gear icon in the top‑right corner of each AI message. Clicking the icon reveals the list of requested tools. When a tool starts running, the chat shows a dark terminal‑style bubble with animated dots that are replaced by the tool's output once it finishes.
 
-The available tools let the model read the focused file, read any file by absolute path, apply unified diff patches and switch the active role between Architect and Code. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`. Custom lists can be supplied by creating a `sona.json` file in the project root:
+The available tools let the model read the focused file, read any file by absolute path, list directory contents, apply unified diff patches and switch the active role between Architect and Code. Directory listings append "/" to folder names and include the first-level contents of each directory. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`. Custom lists can be supplied by creating a `sona.json` file in the project root:
 
 ```
 {

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ToolsMapFactory.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ToolsMapFactory.kt
@@ -46,6 +46,12 @@ class ToolsMapFactory(
                         tools.readFile(path)
                     }
 
+                    "listPath" -> {
+                        val args = gson.fromJson(req.arguments(), Map::class.java) as Map<*, *>
+                        val path = args["arg0"]?.toString() ?: return@create "Empty path"
+                        gson.toJson(tools.listPath(path))
+                    }
+
                     "switchRole" -> {
                         val args = gson.fromJson(req.arguments(), Map::class.java) as Map<*, *>
                         val name = args["name"]?.toString() ?: return@create "Empty role name"

--- a/core/src/main/kotlin/io/qent/sona/core/permissions/DirectoryListing.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/permissions/DirectoryListing.kt
@@ -1,0 +1,6 @@
+package io.qent.sona.core.permissions
+
+data class DirectoryListing(
+    val items: List<String>,
+    val contents: Map<String, List<String>>
+)

--- a/core/src/main/kotlin/io/qent/sona/core/tools/ExternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/ExternalTools.kt
@@ -1,5 +1,6 @@
 package io.qent.sona.core.tools
 
+import io.qent.sona.core.permissions.DirectoryListing
 import io.qent.sona.core.permissions.FileInfo
 import io.qent.sona.core.permissions.FileStructureInfo
 
@@ -8,4 +9,5 @@ interface ExternalTools {
     fun getFileLines(path: String, fromLine: Int, toLine: Int): FileInfo?
     fun readFile(path: String): FileInfo?
     fun applyPatch(patch: String): String
+    fun listPath(path: String): DirectoryListing?
 }

--- a/core/src/main/kotlin/io/qent/sona/core/tools/Tools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/Tools.kt
@@ -1,5 +1,6 @@
 package io.qent.sona.core.tools
 
+import io.qent.sona.core.permissions.DirectoryListing
 import io.qent.sona.core.permissions.FileStructureInfo
 
 interface Tools : InternalTools {
@@ -7,4 +8,5 @@ interface Tools : InternalTools {
     fun getFileLines(path: String, fromLine: Int, toLine: Int): String
     fun readFile(path: String): String
     fun applyPatch(patch: String): String
+    fun listPath(path: String): DirectoryListing
 }

--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
@@ -15,6 +15,7 @@ import io.qent.sona.core.roles.Roles
 import io.qent.sona.core.roles.RolesRepository
 import io.qent.sona.core.settings.Settings
 import io.qent.sona.core.settings.SettingsRepository
+import io.qent.sona.core.permissions.DirectoryListing
 import io.qent.sona.core.permissions.FileStructureInfo
 import io.qent.sona.core.tools.Tools
 import kotlinx.coroutines.*
@@ -56,6 +57,7 @@ private class FakeTools : Tools {
     override fun readFile(path: String) = ""
     override fun applyPatch(patch: String) = ""
     override fun switchRole(name: String) = ""
+    override fun listPath(path: String) = DirectoryListing(emptyList(), emptyMap())
 }
 
 private class FakeSettingsRepository : SettingsRepository {


### PR DESCRIPTION
## Summary
- add `DirectoryListing` data class and implement `listPath` tool
- expose new tool through ToolsMapFactory and PluginExternalTools with permission filtering
- document directory listing tool in AGENTS and README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689b8975d5dc8320ba635cfa3269e822