### PR TITLE
Add tool for retrieving file dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@
   descriptions.
 - A tool lists files and directories for a given path, appending "/" to directory names and
   including the first-level contents of each directory.
+- A tool returns class and object dependencies for a specified file, including paths to files
+  defining those dependencies.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
   environment (OS, IDE, Java, Python, Node.js, file extension statistics, build systems) and is prepended to every LLM request.
 - Any `.md` files in `src/main/resources/prompts` are read at startup and their contents are appended as additional system messages.

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ToolsMapFactory.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ToolsMapFactory.kt
@@ -52,6 +52,12 @@ class ToolsMapFactory(
                         gson.toJson(tools.listPath(path))
                     }
 
+                    "getFileDependencies" -> {
+                        val args = gson.fromJson(req.arguments(), Map::class.java) as Map<*, *>
+                        val path = args["arg0"]?.toString() ?: return@create "Empty file path"
+                        gson.toJson(tools.getFileDependencies(path))
+                    }
+
                     "switchRole" -> {
                         val args = gson.fromJson(req.arguments(), Map::class.java) as Map<*, *>
                         val name = args["name"]?.toString() ?: return@create "Empty role name"

--- a/core/src/main/kotlin/io/qent/sona/core/permissions/FileDependenciesInfo.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/permissions/FileDependenciesInfo.kt
@@ -1,0 +1,14 @@
+package io.qent.sona.core.permissions
+
+/** Information about dependencies of a file. */
+data class FileDependenciesInfo(
+    val path: String,
+    val dependencies: List<FileDependency>,
+)
+
+/** Represents a single dependency and the file that defines it. */
+data class FileDependency(
+    val name: String,
+    val path: String,
+)
+

--- a/core/src/main/kotlin/io/qent/sona/core/tools/ExternalTools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/ExternalTools.kt
@@ -2,6 +2,7 @@ package io.qent.sona.core.tools
 
 import io.qent.sona.core.permissions.DirectoryListing
 import io.qent.sona.core.permissions.FileInfo
+import io.qent.sona.core.permissions.FileDependenciesInfo
 import io.qent.sona.core.permissions.FileStructureInfo
 
 interface ExternalTools {
@@ -10,4 +11,5 @@ interface ExternalTools {
     fun readFile(path: String): FileInfo?
     fun applyPatch(patch: String): String
     fun listPath(path: String): DirectoryListing?
+    fun getFileDependencies(path: String): FileDependenciesInfo?
 }

--- a/core/src/main/kotlin/io/qent/sona/core/tools/Tools.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/Tools.kt
@@ -1,6 +1,7 @@
 package io.qent.sona.core.tools
 
 import io.qent.sona.core.permissions.DirectoryListing
+import io.qent.sona.core.permissions.FileDependenciesInfo
 import io.qent.sona.core.permissions.FileStructureInfo
 
 interface Tools : InternalTools {
@@ -9,4 +10,5 @@ interface Tools : InternalTools {
     fun readFile(path: String): String
     fun applyPatch(patch: String): String
     fun listPath(path: String): DirectoryListing
+    fun getFileDependencies(path: String): FileDependenciesInfo
 }

--- a/core/src/main/kotlin/io/qent/sona/core/tools/ToolsInfoDecorator.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tools/ToolsInfoDecorator.kt
@@ -3,6 +3,7 @@ package io.qent.sona.core.tools
 import dev.langchain4j.agent.tool.Tool
 import io.qent.sona.core.permissions.DirectoryListing
 import io.qent.sona.core.permissions.FilePermissionManager
+import io.qent.sona.core.permissions.FileDependenciesInfo
 import io.qent.sona.core.permissions.FileStructureInfo
 import java.nio.file.Paths
 
@@ -48,6 +49,16 @@ class ToolsInfoDecorator(
                 list.filter { allowed(dirPath, it) }
             }
         return DirectoryListing(items, contents)
+    }
+
+    @Tool("Return dependencies of file at given absolute path")
+    override fun getFileDependencies(path: String): FileDependenciesInfo {
+        if (!filePermissionManager.isFileAllowed(path)) {
+            return FileDependenciesInfo("", emptyList())
+        }
+        val info = externalTools.getFileDependencies(path) ?: return FileDependenciesInfo("", emptyList())
+        val deps = info.dependencies.filter { filePermissionManager.isFileAllowed(it.path) }
+        return FileDependenciesInfo(info.path, deps)
     }
 
     @Tool("Apply a unified diff patch text content to the project")

--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
@@ -17,6 +17,7 @@ import io.qent.sona.core.settings.Settings
 import io.qent.sona.core.settings.SettingsRepository
 import io.qent.sona.core.permissions.DirectoryListing
 import io.qent.sona.core.permissions.FileStructureInfo
+import io.qent.sona.core.permissions.FileDependenciesInfo
 import io.qent.sona.core.tools.Tools
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -58,6 +59,7 @@ private class FakeTools : Tools {
     override fun applyPatch(patch: String) = ""
     override fun switchRole(name: String) = ""
     override fun listPath(path: String) = DirectoryListing(emptyList(), emptyMap())
+    override fun getFileDependencies(path: String) = FileDependenciesInfo(path, emptyList())
 }
 
 private class FakeSettingsRepository : SettingsRepository {

--- a/core/src/test/kotlin/io/qent/sona/core/tools/ToolsInfoDecoratorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/tools/ToolsInfoDecoratorTest.kt
@@ -6,6 +6,7 @@ import io.qent.sona.core.permissions.FileElementType
 import io.qent.sona.core.permissions.FileInfo
 import io.qent.sona.core.permissions.FilePermissionManager
 import io.qent.sona.core.permissions.FilePermissionsRepository
+import io.qent.sona.core.permissions.FileDependenciesInfo
 import io.qent.sona.core.permissions.FileStructureInfo
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -26,6 +27,7 @@ private class FakeExternalTools(
     override fun readFile(path: String): FileInfo? = files[path]
     override fun applyPatch(patch: String) = ""
     override fun listPath(path: String): DirectoryListing? = dirs[path]
+    override fun getFileDependencies(path: String): FileDependenciesInfo? = null
 }
 
 private class FakeInternalTools : InternalTools {

--- a/src/main/kotlin/io/qent/sona/tools/dependencies/FileDependenciesProvider.kt
+++ b/src/main/kotlin/io/qent/sona/tools/dependencies/FileDependenciesProvider.kt
@@ -1,0 +1,8 @@
+package io.qent.sona.tools.dependencies
+
+import com.intellij.psi.PsiFile
+import io.qent.sona.core.permissions.FileDependency
+
+interface FileDependenciesProvider {
+    fun collect(psiFile: PsiFile): List<FileDependency>
+}

--- a/src/main/kotlin/io/qent/sona/tools/dependencies/JavaFileDependenciesProvider.kt
+++ b/src/main/kotlin/io/qent/sona/tools/dependencies/JavaFileDependenciesProvider.kt
@@ -1,0 +1,18 @@
+package io.qent.sona.tools.dependencies
+
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiJavaFile
+import io.qent.sona.core.permissions.FileDependency
+
+class JavaFileDependenciesProvider : FileDependenciesProvider {
+    override fun collect(psiFile: PsiFile): List<FileDependency> {
+        val javaFile = psiFile as? PsiJavaFile ?: return emptyList()
+        val imports = javaFile.importList?.allImportStatements ?: return emptyList()
+        return imports.mapNotNull { stmt ->
+            val ref = stmt.importReference?.resolve() ?: return@mapNotNull null
+            val vFile = ref.containingFile?.virtualFile ?: return@mapNotNull null
+            val name = stmt.importReference?.qualifiedName ?: return@mapNotNull null
+            FileDependency(name, vFile.path)
+        }
+    }
+}

--- a/src/main/kotlin/io/qent/sona/tools/dependencies/KotlinFileDependenciesProvider.kt
+++ b/src/main/kotlin/io/qent/sona/tools/dependencies/KotlinFileDependenciesProvider.kt
@@ -1,0 +1,17 @@
+package io.qent.sona.tools.dependencies
+
+import com.intellij.psi.PsiFile
+import io.qent.sona.core.permissions.FileDependency
+import org.jetbrains.kotlin.psi.KtFile
+
+class KotlinFileDependenciesProvider : FileDependenciesProvider {
+    override fun collect(psiFile: PsiFile): List<FileDependency> {
+        val ktFile = psiFile as? KtFile ?: return emptyList()
+        return ktFile.importDirectives.mapNotNull { directive ->
+            val name = directive.importedFqName?.asString() ?: return@mapNotNull null
+            val target = directive.importedReference?.references?.firstOrNull()?.resolve() ?: return@mapNotNull null
+            val vFile = target.containingFile?.virtualFile ?: return@mapNotNull null
+            FileDependency(name, vFile.path)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose `getFileDependencies` tool to list class and object dependencies for a file
- provide IntelliJ-side implementation resolving imports for Kotlin and Java files
- document new tool availability

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689b99725d6483208da863d551b70c1f