### PR TITLE
Store configuration under hidden .sona directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ API while `InternalTools` live in the core module for plugin interactions like
 switching roles. `ToolsInfoDecorator` combines them and routes file responses through a
 permission manager that checks absolute paths against a whitelist (project root by default)
 and a blacklist of sensitive files before exposing file contents to the model.
-File permissions can also be adjusted by adding a `sona.json` file at the project root with
+File permissions can also be adjusted by adding a `sona.json` file under `.sona` in the project root with
 `permissions.files.whitelist` and `blacklist` arrays of regex patterns.
 `sona.json` may additionally define an `mcpServers` object keyed by server name with Model
 Context Protocol server configurations including `enabled`, `command`, `args`, environment
@@ -76,8 +76,8 @@ disabled tools are stored in `sona.json`; only servers marked as enabled reconne
 automatically on restart.
 The plugin preconfigures two servers: `@jetbrains/mcp-proxy` and `memory`. The
 `memory` server runs `@modelcontextprotocol/server-memory` via `npx` and stores
-its data in `sona_memory.json` at the project root.
-When updating the configuration, merge new values into `sona.json` to preserve any
+its data in `.sona/sona_memory.json` inside the project root.
+When updating the configuration, merge new values into `.sona/sona.json` to preserve any
 user-provided fields instead of overwriting the file.
 `ChatController` receives a `Tools` decorator from `StateProvider` via its injected `ChatAgentFactory`.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ you switch to a different chat.
 
 Tool calls referenced by the model are hidden behind a gear icon in the top‑right corner of each AI message. Clicking the icon reveals the list of requested tools. When a tool starts running, the chat shows a dark terminal‑style bubble with animated dots that are replaced by the tool's output once it finishes.
 
-The available tools let the model read the focused file, read any file by absolute path, list directory contents, run terminal commands from the project root, read terminal output, create unified diff patches for review and apply them later by id, and switch the active role between Architect and Code. Directory listings append "/" to folder names and include the first-level contents of each directory. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`. Custom lists can be supplied by creating a `sona.json` file in the project root:
+The available tools let the model read the focused file, read any file by absolute path, list directory contents, run terminal commands from the project root, read terminal output, create unified diff patches for review and apply them later by id, and switch the active role between Architect and Code. Directory listings append "/" to folder names and include the first-level contents of each directory. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`. Custom lists can be supplied by creating a `sona.json` file inside `.sona` in the project root:
 
 ```
 {
@@ -126,19 +126,19 @@ not affect the plugin. Tools provided by MCP servers require the same user confi
 
 Sona ships with two predefined servers: `@jetbrains/mcp-proxy` and `memory`. The
 `memory` server uses `@modelcontextprotocol/server-memory` via `npx` and stores
-its state in `sona_memory.json` at the project root. When this server is enabled,
+its state in `.sona/sona_memory.json` at the project root. When this server is enabled,
 its usage instructions from `prompts/memory_instructions.md` are appended to the
 system messages sent with each request.
 
 The tool window includes a **Servers** action listing all configured MCP servers. Each server is shown as a card
 with a coloured status indicator – grey for disabled, red when a connection fails, yellow while connecting and
 green once connected and exposing tools. Clicking a card toggles the server on or off. A refresh button above
-the list reloads `sona.json` and reconnects previously enabled servers. A pinned **Редактировать конфигурацию**
-button at the bottom opens `sona.json`, creating it with the current server configuration and file permission
-lists when missing. Server enablement is stored in `sona.json` so only servers marked as enabled start
+the list reloads `.sona/sona.json` and reconnects previously enabled servers. A pinned **Редактировать конфигурацию**
+button at the bottom opens `.sona/sona.json`, creating it with the current server configuration and file permission
+lists when missing. Server enablement is stored in `.sona/sona.json` so only servers marked as enabled start
 automatically after restarting the IDE. Connected servers expand to show their tools with a green indicator next
 to each one. Clicking the indicator disables the tool, turning it grey and excluding it from future LLM requests.
-Disabled tool names persist in `sona.json` under the server's `disabledTools` array.
+Disabled tool names persist in `.sona/sona.json` under the server's `disabledTools` array.
 
 ```json
 {

--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
@@ -94,7 +94,7 @@ private fun buildChatController(repo: FakeChatRepository): ChatDeps {
     val scope = CoroutineScope(Dispatchers.Unconfined)
     val mcpManager = McpConnectionManager(EmptyMcpRepository(), scope)
     val settingsRepo = FakeSettingsRepository()
-    val stateFlow = ChatStateFlow(repo, scope)
+    val stateFlow = ChatStateFlow(repo)
     val permissioned = PermissionedToolExecutor(stateFlow, repo)
     val toolsMapFactory = ToolsMapFactory(stateFlow, tools, mcpManager, permissioned, rolesRepo, presetsRepo)
     val agentFactory = ChatAgentFactory({ throw UnsupportedOperationException() }, { emptyList() }, toolsMapFactory, presetsRepo, rolesRepo, repo)

--- a/core/src/test/kotlin/io/qent/sona/core/tools/ToolsInfoDecoratorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/tools/ToolsInfoDecoratorTest.kt
@@ -59,7 +59,7 @@ private fun testChatStateFlow(): ChatStateFlow {
         override suspend fun deleteChat(chatId: String) {}
         override suspend fun deleteMessagesFrom(chatId: String, index: Int) {}
     }
-    return ChatStateFlow(repo, CoroutineScope(Dispatchers.Unconfined)).apply {
+    return ChatStateFlow(repo).apply {
         emit(Chat("1", TokenUsageInfo()))
     }
 }

--- a/src/main/kotlin/io/qent/sona/config/SonaConfig.kt
+++ b/src/main/kotlin/io/qent/sona/config/SonaConfig.kt
@@ -32,14 +32,15 @@ class SonaConfig {
 
     companion object {
         fun load(root: String): SonaConfig? {
-            val file = File(root, "sona.json")
+            val file = File(File(root, ".sona"), "sona.json")
             return runCatching {
                 if (file.exists()) file.reader().use { Gson().fromJson(it, SonaConfig::class.java) } else null
             }.getOrNull()
         }
 
         fun save(root: String, config: SonaConfig) {
-            val file = File(root, "sona.json")
+            val file = File(File(root, ".sona"), "sona.json")
+            file.parentFile?.mkdirs()
             val gson: Gson = GsonBuilder().setPrettyPrinting().create()
 
             val newJson = gson.toJsonTree(config).asJsonObject

--- a/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginMcpServersRepository.kt
@@ -50,7 +50,7 @@ class PluginMcpServersRepository(private val project: Project) : McpServersRepos
                     name = "memory",
                     command = "npx",
                     args = MEMORY_MCP_ARGS,
-                    env = mapOf("MEMORY_FILE_PATH" to File(root, "sona_memory.json").absolutePath),
+                    env = mapOf("MEMORY_FILE_PATH" to File(root, ".sona/sona_memory.json").absolutePath),
                     transport = "stdio"
                 )
             )
@@ -65,7 +65,7 @@ class PluginMcpServersRepository(private val project: Project) : McpServersRepos
     }
 
     override suspend fun saveEnabled(enabled: Set<String>) {
-        val file = File(root, "sona.json")
+        val file = File(root, ".sona/sona.json")
         if (!file.exists()) return
         val config = SonaConfig.load(root) ?: SonaConfig()
         val servers = config.mcpServers?.toMutableMap() ?: mutableMapOf()
@@ -82,7 +82,7 @@ class PluginMcpServersRepository(private val project: Project) : McpServersRepos
     }
 
     override suspend fun saveDisabledTools(disabled: Map<String, Set<String>>) {
-        val file = File(root, "sona.json")
+        val file = File(root, ".sona/sona.json")
         if (!file.exists()) return
         val config = SonaConfig.load(root) ?: SonaConfig()
         val servers = config.mcpServers?.toMutableMap() ?: mutableMapOf()
@@ -96,7 +96,7 @@ class PluginMcpServersRepository(private val project: Project) : McpServersRepos
     }
 
     fun openConfig() {
-        val file = File(root, "sona.json")
+        val file = File(root, ".sona/sona.json")
         if (!file.exists()) {
             val enabledSet = runBlocking { loadEnabled() }
             val servers = runBlocking { list() }

--- a/src/test/kotlin/io/qent/sona/config/SonaConfigTest.kt
+++ b/src/test/kotlin/io/qent/sona/config/SonaConfigTest.kt
@@ -12,7 +12,8 @@ class SonaConfigTest {
     @Test
     fun `saving merges with existing json`() {
         val dir = Files.createTempDirectory("sonaTest").toFile()
-        val file = File(dir, "sona.json")
+        val file = File(dir, ".sona/sona.json")
+        file.parentFile.mkdirs()
         file.writeText("{\"foo\":\"bar\",\"permissions\":{\"files\":{\"whitelist\":[\"a\"]}}}")
 
         val config = SonaConfig()


### PR DESCRIPTION
## Summary
- Load and save plugin configuration from `.sona/sona.json` and keep data under `.sona`
- Point default memory MCP server to `.sona/sona_memory.json`
- Document new configuration directory and adjust tests to match

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689cd95ffaec8320b98e7122d67f08be