### PR TITLE
Detect same-package Kotlin dependencies

### DIFF
--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
@@ -94,7 +94,7 @@ private fun buildChatController(repo: FakeChatRepository): ChatDeps {
     val scope = CoroutineScope(Dispatchers.Unconfined)
     val mcpManager = McpConnectionManager(EmptyMcpRepository(), scope)
     val settingsRepo = FakeSettingsRepository()
-    val stateFlow = ChatStateFlow(repo, scope)
+    val stateFlow = ChatStateFlow(repo)
     val permissioned = PermissionedToolExecutor(stateFlow, repo)
     val toolsMapFactory = ToolsMapFactory(stateFlow, tools, mcpManager, permissioned, rolesRepo, presetsRepo)
     val agentFactory = ChatAgentFactory({ throw UnsupportedOperationException() }, { emptyList() }, toolsMapFactory, presetsRepo, rolesRepo, repo)

--- a/core/src/test/kotlin/io/qent/sona/core/tools/ToolsInfoDecoratorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/tools/ToolsInfoDecoratorTest.kt
@@ -59,7 +59,7 @@ private fun testChatStateFlow(): ChatStateFlow {
         override suspend fun deleteChat(chatId: String) {}
         override suspend fun deleteMessagesFrom(chatId: String, index: Int) {}
     }
-    return ChatStateFlow(repo, CoroutineScope(Dispatchers.Unconfined)).apply {
+    return ChatStateFlow(repo).apply {
         emit(Chat("1", TokenUsageInfo()))
     }
 }

--- a/src/main/kotlin/io/qent/sona/tools/dependencies/KotlinFileDependenciesProvider.kt
+++ b/src/main/kotlin/io/qent/sona/tools/dependencies/KotlinFileDependenciesProvider.kt
@@ -1,17 +1,54 @@
 package io.qent.sona.tools.dependencies
 
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
 import io.qent.sona.core.permissions.FileDependency
-import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.*
 
 class KotlinFileDependenciesProvider : FileDependenciesProvider {
     override fun collect(psiFile: PsiFile): List<FileDependency> {
         val ktFile = psiFile as? KtFile ?: return emptyList()
-        return ktFile.importDirectives.mapNotNull { directive ->
-            val name = directive.importedFqName?.asString() ?: return@mapNotNull null
-            val target = directive.importedReference?.references?.firstOrNull()?.resolve() ?: return@mapNotNull null
-            val vFile = target.containingFile?.virtualFile ?: return@mapNotNull null
-            FileDependency(name, vFile.path)
+
+        val deps = mutableListOf<FileDependency>()
+        val seen = mutableSetOf<String>()
+
+        // Explicit imports
+        ktFile.importDirectives.forEach { directive ->
+            val name = directive.importedFqName?.asString() ?: return@forEach
+            val target = directive.importedReference?.references?.firstOrNull()?.resolve() ?: return@forEach
+            val vFile = target.containingFile?.virtualFile ?: return@forEach
+            if (seen.add(name)) deps.add(FileDependency(name, vFile.path))
         }
+
+        // Same-package references without imports
+        val pkg = ktFile.packageFqName.asString()
+        ktFile.accept(object : KtTreeVisitorVoid() {
+            override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
+                super.visitSimpleNameExpression(expression)
+
+                val target = expression.references.firstOrNull()?.resolve() ?: return
+                val targetFile = target.containingFile ?: return
+                if (targetFile == psiFile) return
+
+                val fqName = when (target) {
+                    is KtClassOrObject -> target.fqName?.asString()
+                    is PsiClass -> target.qualifiedName
+                    else -> null
+                } ?: return
+
+                val targetPkg = when (target) {
+                    is KtClassOrObject -> target.containingKtFile.packageFqName.asString()
+                    is PsiClass -> target.qualifiedName?.substringBeforeLast('.', "")
+                    else -> null
+                }
+
+                if (targetPkg != pkg) return
+
+                val vFile = targetFile.virtualFile ?: return
+                if (seen.add(fqName)) deps.add(FileDependency(fqName, vFile.path))
+            }
+        })
+
+        return deps
     }
 }

--- a/src/test/kotlin/io/qent/sona/tools/dependencies/KotlinFileDependenciesProviderTest.kt
+++ b/src/test/kotlin/io/qent/sona/tools/dependencies/KotlinFileDependenciesProviderTest.kt
@@ -1,0 +1,25 @@
+package io.qent.sona.tools.dependencies
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.jetbrains.kotlin.psi.KtFile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+
+class KotlinFileDependenciesProviderTest : BasePlatformTestCase() {
+    fun `test detects same package dependency`() {
+        myFixture.addFileToProject(
+            "src/com/example/Other.kt",
+            "package com.example\nclass Other"
+        )
+        val file = myFixture.addFileToProject(
+            "src/com/example/Use.kt",
+            "package com.example\nclass Use { val o = Other() }"
+        ) as KtFile
+
+        val deps = KotlinFileDependenciesProvider().collect(file)
+        assertEquals(1, deps.size)
+        val dep = deps.first()
+        assertEquals("com.example.Other", dep.name)
+        assertTrue(dep.path.endsWith("Other.kt"))
+    }
+}


### PR DESCRIPTION
## Summary
- expand KotlinFileDependenciesProvider to resolve same-package class and object references by walking PSI tree
- add test verifying same-package dependencies are reported
- adjust outdated tests to use current ChatStateFlow signature

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689cda9f8e008320a05cf050a27bf131