### PR TITLE
Show localized text when model requests tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ requests in the current chat. When enabled, tools run without prompting until
 you switch to a different chat.
 
 Tool calls referenced by the model are hidden behind a gear icon in the top‑right corner of each AI message. Clicking the icon reveals the list of requested tools. When a tool starts running, the chat shows a dark terminal‑style bubble with animated dots that are replaced by the tool's output once it finishes.
+If the model message contains only a tool request, the chat displays a note like "Sona is calling tool '<tool>'" instead of an empty response.
 
 The available tools let the model read the focused file, read any file by absolute path, list directory contents, run terminal commands from the project root, read terminal output, create unified diff patches for review and apply them later by id, and switch the active role between Architect and Code. Directory listings append "/" to folder names and include the first-level contents of each directory. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`. Custom lists can be supplied by creating a `sona.json` file inside `.sona` in the project root:
 

--- a/src/main/kotlin/io/qent/sona/Strings.kt
+++ b/src/main/kotlin/io/qent/sona/Strings.kt
@@ -76,5 +76,6 @@ object Strings {
     val userSystemPromptActionDescription: String get() = bundle.getString("userSystemPromptActionDescription")
     val userSystemPrompt: String get() = bundle.getString("userSystemPrompt")
     val terminalCommandSent: String get() = bundle.getString("terminalCommandSent")
+    val toolCalling: String get() = bundle.getString("toolCalling")
 }
 

--- a/src/main/kotlin/io/qent/sona/ui/chat/AiWithToolsMessageBubble.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/AiWithToolsMessageBubble.kt
@@ -31,6 +31,12 @@ fun AiWithToolsMessageBubble(
     var expanded by remember { mutableStateOf(false) }
     val background = SonaTheme.colors.Background
     val borderColor = Color.White.copy(alpha = 0.12f)
+    val messageText = if (message.text.isEmpty() && message.toolRequests.isNotEmpty()) {
+        val toolNames = message.toolRequests.joinToString(", ") { it.name() }
+        String.format(Strings.toolCalling, toolNames)
+    } else {
+        message.text
+    }
 
     Column(Modifier.fillMaxWidth()) {
         // Header row: main text + toggle
@@ -41,7 +47,7 @@ fun AiWithToolsMessageBubble(
         ) {
             SelectionContainer(Modifier.weight(1f).padding(bottom = 12.dp).padding(horizontal = 8.dp)) {
                 Text(
-                    message.text,
+                    messageText,
                     color = LocalTypography.current.text.color,
                     fontSize = LocalTypography.current.text.fontSize,
                 )

--- a/src/main/kotlin/io/qent/sona/ui/chat/MessageBubble.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/MessageBubble.kt
@@ -42,14 +42,19 @@ fun MessageBubble(
     onEdit: () -> Unit,
     onScrollOutside: (Float) -> Unit,
 ) {
-    if (message is UiMessage.Ai && message.text.isEmpty()) return
+    val messageText = if (message is UiMessage.Ai && message.text.isEmpty()) {
+        if (message.toolRequests.isEmpty()) return
+        val toolNames = message.toolRequests.joinToString(", ") { it.name() }
+        String.format(Strings.toolCalling, toolNames)
+    } else {
+        message.text
+    }
 
     val isUser = message is UiMessage.User
     var hovered by remember { mutableStateOf(false) }
     val clipboard = LocalClipboardManager.current
     val background = if (isUser) SonaTheme.colors.UserBubble else SonaTheme.colors.Background
     val textColor = if (isUser) SonaTheme.colors.UserText else SonaTheme.colors.AiText
-    val messageText = message.text
     var showTools by remember { mutableStateOf(false) }
     val borderColor by remember { mutableStateOf(Color.White.copy(alpha = 0.12f)) }
 
@@ -84,7 +89,7 @@ fun MessageBubble(
                         .padding(horizontal = if (isUser) 8.dp else 0.dp)
                 ) {
                     if (message is UiMessage.Ai) {
-                        val mdState = rememberMarkdownState(message.text, immediate = true)
+                        val mdState = rememberMarkdownState(messageText, immediate = true)
                         Markdown(
                             mdState,
                             colors = SonaTheme.markdownColors,
@@ -112,7 +117,7 @@ fun MessageBubble(
                         )
                     } else if (message is UiMessage.User) {
                         Text(
-                            message.text,
+                            messageText,
                             color = textColor,
                             fontSize = 15.sp
                         )

--- a/src/main/resources/messages/Strings.properties
+++ b/src/main/resources/messages/Strings.properties
@@ -68,3 +68,4 @@ deleteChatQuestion=Delete chat?
 shortDescription=Short description
 userSystemPrompt=User system prompt
 terminalCommandSent=Command sent to terminal
+toolCalling=Sona is calling tool '%s'

--- a/src/main/resources/messages/Strings_de.properties
+++ b/src/main/resources/messages/Strings_de.properties
@@ -68,3 +68,4 @@ deleteChatQuestion=Chat löschen?
 shortDescription=Kurze Beschreibung
 userSystemPrompt=Benutzer-Systemprompt
 terminalCommandSent=Befehl an Terminal gesendet
+toolCalling=Sona ruft das Werkzeug '%s' auf

--- a/src/main/resources/messages/Strings_fr.properties
+++ b/src/main/resources/messages/Strings_fr.properties
@@ -68,3 +68,4 @@ deleteChatQuestion=Supprimer le chat ?
 shortDescription=Brève description
 userSystemPrompt=Invite système utilisateur
 terminalCommandSent=Commande envoyée au terminal
+toolCalling=Sona appelle l’outil '%s'

--- a/src/main/resources/messages/Strings_ru.properties
+++ b/src/main/resources/messages/Strings_ru.properties
@@ -68,3 +68,4 @@ deleteChatQuestion=Удалить чат?
 shortDescription=Краткое описание
 userSystemPrompt=Системное сообщение пользователя
 terminalCommandSent=Команда отправлена в терминал
+toolCalling=Sona обращается к инструменту '%s'

--- a/src/main/resources/messages/Strings_zh.properties
+++ b/src/main/resources/messages/Strings_zh.properties
@@ -68,3 +68,4 @@ deleteChatQuestion=删除聊天？
 shortDescription=简短描述
 userSystemPrompt=用户系统提示
 terminalCommandSent=命令已发送到终端
+toolCalling=Sona 正在调用工具 '%s'


### PR DESCRIPTION
## Summary
- Display a localized fallback message when the model sends only a tool request
- Localize the fallback text across all supported languages
- Document tool-only messages in the README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689dee99ea6c8320bd196bd93fe1d764