### PR TITLE
Cancel streaming when chat stop is pressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Chat with various language models directly from a side panel in your IDE. The ch
 history is persisted in IDE storage so it survives restarts. Connection details are
 managed as presets where you choose a provider, model, API endpoint and token. Responses stream
 gradually so you can watch them being generated in real time and stop the stream at any moment
-to keep the partial reply. The interface is available in English, Russian, Chinese, German, and French. Under the hood the core relies on langchain4j `AiService` and
+to keep the partial reply. Stopping cancels the active LLM request. The interface is available in English, Russian, Chinese, German, and French. Under the hood the core relies on langchain4j `AiService` and
 `TokenStream` to deliver partial responses and tool execution events via streaming callbacks.
 
 <!-- Plugin description -->


### PR DESCRIPTION
## Summary
- cancel active streaming requests when the chat is stopped
- note cancellation behavior in README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689dc146c8948320a64375f92923c39c