### PR TITLE
Include project root path in startup system prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 - A tool returns class and object dependencies for a specified file, including paths to files
   defining those dependencies.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
-  environment (OS, IDE, Java, Python, Node.js, file extension statistics, build systems) and is prepended to every LLM request.
+  environment (OS, IDE, Java, Python, Node.js, project root path, file extension statistics, build systems) and is prepended to every LLM request.
 - Any `.md` files in `src/main/resources/prompts` are read at startup and their contents are appended as additional system messages.
 - ChatController leverages langchain4j `AiService` and `TokenStream` to emit partial responses and tool events via streaming callbacks.
 - AI messages show a gear icon that toggles visibility of requested tools. Tool outputs stream into a terminal-style bubble with animated dots until completion.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The active role can also be changed directly from the chat via the selector
 under the message input. The text of the active role is sent as a system message
 with every request but is not stored in the chat history. Every request is also
 prefixed with a system message summarizing
-the current environment (OS, IDE, Java, Python, Node.js versions, file extension
+the current environment (OS, IDE, Java, Python, Node.js versions, project root path, file extension
 statistics and build systems). On startup the plugin also reads any `.md` files in
 `src/main/resources/prompts` and appends their text as additional system messages.
 A user-specific system prompt can be edited from the toolbar and is included with every request when set.

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -256,6 +256,7 @@ class PluginStateFlow(private val project: Project) : Flow<State>, Disposable {
         val python = runCommand("python", "--version")
         val node = runCommand("node", "--version")
         val base = project.basePath?.let { File(it) }
+        val root = base?.absolutePath ?: "Unknown"
         val builds = detectBuildSystems(base)
         return listOf(
             "OS: $os",
@@ -264,6 +265,7 @@ class PluginStateFlow(private val project: Project) : Flow<State>, Disposable {
             "Python: $python",
             "Node: $node",
             "Build: $builds",
+            "Project root: $root",
         ).joinToString("\n")
     }
 


### PR DESCRIPTION
## Summary
- include project root file system path in the environment system message
- document project root path in startup prompts

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689e10cff6188320af3759387805a7d4