### PR TITLE
Handle missing tool result messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
   environment (OS, IDE, Java, Python, Node.js, file extension statistics, build systems) and is prepended to every LLM request.
 - Any `.md` files in `src/main/resources/prompts` are read at startup and their contents are appended as additional system messages.
 - ChatController leverages langchain4j `AiService` and `TokenStream` to emit partial responses and tool events via streaming callbacks.
+- When preparing messages for the `AiService`, append a `ToolExecutionResultMessage` with localized text `Strings.connectionError` after any `AiMessage` that requests a tool but lacks a following result message and persist it to the chat repository.
 - AI messages show a gear icon that toggles visibility of requested tools. Tool outputs stream into a terminal-style bubble with animated dots until completion.
 - Run `./gradlew build` before committing any changes.
 - After completing a task, make sure `AGENTS.md` and `README.md` reflect the latest behavior.

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatAgentFactory.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatAgentFactory.kt
@@ -15,6 +15,7 @@ class ChatAgentFactory(
     private val presetsRepository: PresetsRepository,
     private val rolesRepository: RolesRepository,
     private val chatRepository: ChatRepository,
+    private val connectionErrorText: String,
 ) {
     suspend fun create(): SonaAiService {
         val preset = presetsRepository.load().let { it.presets[it.active] }
@@ -26,7 +27,7 @@ class ChatAgentFactory(
         return AiServices.builder(SonaAiService::class.java)
             .streamingChatModel(modelFactory(preset))
             .systemMessageProvider { (systemMessages() + roleMessage).joinToString("\n") }
-            .chatMemoryProvider { id -> ChatRepositoryChatMemoryStore(chatRepository, id.toString()) }
+            .chatMemoryProvider { id -> ChatRepositoryChatMemoryStore(chatRepository, id.toString(), connectionErrorText) }
             .tools(toolsMap)
             .build()
     }

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatRepositoryChatMemoryStore.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatRepositoryChatMemoryStore.kt
@@ -1,6 +1,9 @@
 package io.qent.sona.core.chat
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest
+import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ChatMessage
+import dev.langchain4j.data.message.ToolExecutionResultMessage
 import dev.langchain4j.memory.ChatMemory
 import kotlinx.coroutines.runBlocking
 
@@ -13,10 +16,12 @@ import kotlinx.coroutines.runBlocking
 class ChatRepositoryChatMemoryStore(
     private val chatRepository: ChatRepository,
     private val chatId: String,
+    private val connectionErrorText: String,
 ) : ChatMemory {
 
     private val messages: MutableList<ChatMessage> = runBlocking {
-        chatRepository.loadMessages(chatId).map { it.message }.toMutableList()
+        val repoMessages = chatRepository.loadMessages(chatId).toMutableList()
+        fixDanglingToolRequests(repoMessages).map { it.message }.toMutableList()
     }
 
     override fun id(): Any = chatId
@@ -29,5 +34,45 @@ class ChatRepositoryChatMemoryStore(
 
     override fun clear() {
         messages.clear()
+    }
+
+    private suspend fun fixDanglingToolRequests(messages: MutableList<ChatRepositoryMessage>): List<ChatRepositoryMessage> {
+        val fixed = mutableListOf<ChatRepositoryMessage>()
+        val pending = mutableListOf<ToolExecutionRequest>()
+        for (msg in messages) {
+            when (val m = msg.message) {
+                is AiMessage -> {
+                    fixed += msg
+                    pending += m.toolExecutionRequests()
+                }
+                is ToolExecutionResultMessage -> {
+                    val removed = pending.removeAll { it.id() == m.id() }
+                    if (removed) fixed += msg
+                }
+                else -> {
+                    if (pending.isNotEmpty()) {
+                        pending.forEach { req ->
+                            val result = ToolExecutionResultMessage(req.id(), req.name(), connectionErrorText)
+                            fixed += ChatRepositoryMessage(chatId, result, "")
+                        }
+                        pending.clear()
+                    }
+                    fixed += msg
+                }
+            }
+        }
+        if (pending.isNotEmpty()) {
+            pending.forEach { req ->
+                val result = ToolExecutionResultMessage(req.id(), req.name(), connectionErrorText)
+                fixed += ChatRepositoryMessage(chatId, result, "")
+            }
+        }
+        if (fixed.size != messages.size) {
+            chatRepository.deleteMessagesFrom(chatId, 0)
+            for (m in fixed) {
+                chatRepository.addMessage(chatId, m.message, m.model, m.tokenUsage)
+            }
+        }
+        return fixed
     }
 }

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
@@ -55,6 +55,7 @@ class StateProvider(
     private val editConfig: () -> Unit,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     systemMessages: () -> List<SystemMessage> = { emptyList() },
+    connectionErrorText: String,
     logger: Logger = Logger.NoOp,
 ) {
     private val filePermissionManager = FilePermissionManager(filePermissionRepository)
@@ -91,7 +92,8 @@ class StateProvider(
         toolsMapFactory,
         presetsRepository,
         rolesRepository,
-        chatRepository
+        chatRepository,
+        connectionErrorText,
     )
     private val chatController = ChatController(
         presetsRepository,

--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
@@ -49,7 +49,9 @@ private class FakeChatRepository : ChatRepository {
     override suspend fun addAllowedTool(chatId: String, toolName: String) { allowed.add(toolName) }
     override suspend fun listChats() = emptyList<ChatSummary>()
     override suspend fun deleteChat(chatId: String) {}
-    override suspend fun deleteMessagesFrom(chatId: String, index: Int) {}
+    override suspend fun deleteMessagesFrom(chatId: String, index: Int) {
+        messages[chatId]?.apply { if (index < size) subList(index, size).clear() }
+    }
 }
 
 private class FakeTools : Tools {
@@ -97,7 +99,7 @@ private fun buildChatController(repo: FakeChatRepository): ChatDeps {
     val stateFlow = ChatStateFlow(repo)
     val permissioned = PermissionedToolExecutor(stateFlow, repo)
     val toolsMapFactory = ToolsMapFactory(stateFlow, tools, mcpManager, permissioned, rolesRepo, presetsRepo)
-    val agentFactory = ChatAgentFactory({ throw UnsupportedOperationException() }, { emptyList() }, toolsMapFactory, presetsRepo, rolesRepo, repo)
+    val agentFactory = ChatAgentFactory({ throw UnsupportedOperationException() }, { emptyList() }, toolsMapFactory, presetsRepo, rolesRepo, repo, "error")
     val controller = ChatController(presetsRepo, repo, settingsRepo, stateFlow, agentFactory, scope)
     return ChatDeps(controller, stateFlow, permissioned, scope, mcpManager)
 }

--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatRepositoryChatMemoryStoreTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatRepositoryChatMemoryStoreTest.kt
@@ -1,0 +1,49 @@
+package io.qent.sona.core.chat
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.ToolExecutionResultMessage
+import dev.langchain4j.data.message.UserMessage
+import io.qent.sona.core.model.TokenUsageInfo
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatRepositoryChatMemoryStoreTest {
+    private class FakeChatRepository : ChatRepository {
+        val messages = mutableMapOf<String, MutableList<ChatRepositoryMessage>>()
+        override suspend fun createChat(): String = "1"
+        override suspend fun addMessage(chatId: String, message: dev.langchain4j.data.message.ChatMessage, model: String, tokenUsage: TokenUsageInfo) {
+            messages.getOrPut(chatId) { mutableListOf() }.add(ChatRepositoryMessage(chatId, message, model, tokenUsage))
+        }
+        override suspend fun loadMessages(chatId: String) = messages[chatId] ?: emptyList()
+        override suspend fun loadTokenUsage(chatId: String) = TokenUsageInfo()
+        override suspend fun isToolAllowed(chatId: String, toolName: String) = false
+        override suspend fun addAllowedTool(chatId: String, toolName: String) {}
+        override suspend fun listChats() = emptyList<ChatSummary>()
+        override suspend fun deleteChat(chatId: String) {}
+        override suspend fun deleteMessagesFrom(chatId: String, index: Int) {
+            messages[chatId]?.apply { if (index < size) subList(index, size).clear() }
+        }
+    }
+
+    @Test
+    fun insertsPlaceholderBeforeNextUserMessage() = runBlocking {
+        val repo = FakeChatRepository()
+        val req = ToolExecutionRequest.builder().id("x").name("t").arguments("{}").build()
+        val ai = AiMessage("", listOf(req))
+        val user = UserMessage.from("hi")
+        repo.messages["1"] = mutableListOf(
+            ChatRepositoryMessage("1", ai, "m"),
+            ChatRepositoryMessage("1", user, "m"),
+        )
+        val store = ChatRepositoryChatMemoryStore(repo, "1", "error")
+        val msgs = store.messages()
+        assertEquals(3, msgs.size)
+        val result = msgs[1] as ToolExecutionResultMessage
+        assertEquals("error", result.text())
+        val stored = repo.messages["1"]!!
+        assertEquals(3, stored.size)
+        assertEquals(result, stored[1].message)
+    }
+}

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -176,6 +176,7 @@ class PluginStateFlow(private val project: Project) : Flow<State>, Disposable {
             editConfig = { project.service<PluginMcpServersRepository>().openConfig() },
             scope = scope,
             systemMessages = { createSystemMessages() },
+            connectionErrorText = Strings.connectionError,
             logger = IdeaLogger,
         )
 

--- a/src/main/kotlin/io/qent/sona/Strings.kt
+++ b/src/main/kotlin/io/qent/sona/Strings.kt
@@ -77,5 +77,6 @@ object Strings {
     val userSystemPrompt: String get() = bundle.getString("userSystemPrompt")
     val terminalCommandSent: String get() = bundle.getString("terminalCommandSent")
     val toolCalling: String get() = bundle.getString("toolCalling")
+    val connectionError: String get() = bundle.getString("connectionError")
 }
 

--- a/src/main/resources/messages/Strings.properties
+++ b/src/main/resources/messages/Strings.properties
@@ -69,3 +69,4 @@ shortDescription=Short description
 userSystemPrompt=User system prompt
 terminalCommandSent=Command sent to terminal
 toolCalling=Sona is calling tool '%s'
+connectionError=Connection error

--- a/src/main/resources/messages/Strings_de.properties
+++ b/src/main/resources/messages/Strings_de.properties
@@ -69,3 +69,4 @@ shortDescription=Kurze Beschreibung
 userSystemPrompt=Benutzer-Systemprompt
 terminalCommandSent=Befehl an Terminal gesendet
 toolCalling=Sona ruft das Werkzeug '%s' auf
+connectionError=Verbindungsfehler

--- a/src/main/resources/messages/Strings_fr.properties
+++ b/src/main/resources/messages/Strings_fr.properties
@@ -69,3 +69,4 @@ shortDescription=Brève description
 userSystemPrompt=Invite système utilisateur
 terminalCommandSent=Commande envoyée au terminal
 toolCalling=Sona appelle l’outil '%s'
+connectionError=Erreur de connexion

--- a/src/main/resources/messages/Strings_ru.properties
+++ b/src/main/resources/messages/Strings_ru.properties
@@ -69,3 +69,4 @@ shortDescription=Краткое описание
 userSystemPrompt=Системное сообщение пользователя
 terminalCommandSent=Команда отправлена в терминал
 toolCalling=Sona обращается к инструменту '%s'
+connectionError=Ошибка соединения

--- a/src/main/resources/messages/Strings_zh.properties
+++ b/src/main/resources/messages/Strings_zh.properties
@@ -69,3 +69,4 @@ shortDescription=简短描述
 userSystemPrompt=用户系统提示
 terminalCommandSent=命令已发送到终端
 toolCalling=Sona 正在调用工具 '%s'
+connectionError=连接错误


### PR DESCRIPTION
## Summary
- localize connection error placeholder and provide translations
- persist inserted tool error messages to the chat repository
- thread localized string through state and agent factories

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689e019b5b00832098f9783a26348257