### PR TITLE
feat: add project system prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
   defining those dependencies.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
   environment (OS, IDE, Java, Python, Node.js, project root path, file extension statistics, build systems) and is prepended to every LLM request.
-- Any `.md` files in `src/main/resources/prompts` are read at startup and their contents are appended as additional system messages.
+- Any `.md` files in `src/main/resources/prompts` are read at startup and their contents are appended as additional system messages. If the user's project contains a `.sona/prompts` directory, `.md` files inside are also added as system prompts.
 - ChatController leverages langchain4j `AiService` and `TokenStream` to emit partial responses and tool events via streaming callbacks.
 - When preparing messages for the `AiService`, append a `ToolExecutionResultMessage` with localized text `Strings.connectionError` after any `AiMessage` that requests a tool but lacks a following result message and persist it to the chat repository.
 - AI messages show a gear icon that toggles visibility of requested tools. Tool outputs stream into a terminal-style bubble with animated dots until completion.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ with every request but is not stored in the chat history. Every request is also
 prefixed with a system message summarizing
 the current environment (OS, IDE, Java, Python, Node.js versions, project root path, file extension
 statistics and build systems). On startup the plugin also reads any `.md` files in
-`src/main/resources/prompts` and appends their text as additional system messages.
+`src/main/resources/prompts` and appends their text as additional system messages. If the user's project
+contains a `.sona/prompts` directory, any `.md` files inside are also read and added as system messages.
 A user-specific system prompt can be edited from the toolbar and is included with every request when set.
 
 Models can also switch roles themselves using a tool that selects a role by name.

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -233,12 +233,19 @@ class PluginStateFlow(private val project: Project) : Flow<State>, Disposable {
                 messages += SystemMessage.from(it.reader().readText())
             }
         }
+        messages += loadProjectSystemPrompts()
         return messages
     }
 
     private fun isMemoryServerEnabled(): Boolean {
         val repo = project.service<PluginMcpServersRepository>()
         return runBlocking { repo.loadEnabled().contains("memory") }
+    }
+
+    private fun loadProjectSystemPrompts(): List<SystemMessage> {
+        val base = project.basePath ?: return emptyList()
+        val path = Paths.get(base, ".sona", "prompts")
+        return if (Files.isDirectory(path)) loadMessagesFromPath(path) else emptyList()
     }
 
     private fun loadMessagesFromPath(path: Path): List<SystemMessage> {


### PR DESCRIPTION
## Summary
- load `.md` prompts from project `.sona/prompts` directory and append to system messages
- document project prompt directory usage

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a3110c4e808320af85f5d403cfa2de