### PR TITLE
feat: load project prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
   defining those dependencies.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
   environment (OS, IDE, Java, Python, Node.js, project root path, file extension statistics, build systems) and is prepended to every LLM request.
-- Any `.md` files in `src/main/resources/prompts` are read at startup and their contents are appended as additional system messages.
+  - Any `.md` files in `src/main/resources/prompts` are bundled. Projects may provide `.md` files in `.sona/prompts` that apply to all roles and in `.sona/prompts/{role}` for role-specific messages; all are appended as additional system messages.
 - ChatController leverages langchain4j `AiService` and `TokenStream` to emit partial responses and tool events via streaming callbacks.
 - When preparing messages for the `AiService`, append a `ToolExecutionResultMessage` with localized text `Strings.connectionError` after any `AiMessage` that requests a tool but lacks a following result message and persist it to the chat repository.
 - AI messages show a gear icon that toggles visibility of requested tools. Tool outputs stream into a terminal-style bubble with animated dots until completion.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ under the message input. The text of the active role is sent as a system message
 with every request but is not stored in the chat history. Every request is also
 prefixed with a system message summarizing
 the current environment (OS, IDE, Java, Python, Node.js versions, project root path, file extension
-statistics and build systems). On startup the plugin also reads any `.md` files in
-`src/main/resources/prompts` and appends their text as additional system messages.
+statistics and build systems). The plugin also reads any `.md` files in `src/main/resources/prompts`.
+Projects can provide their own prompts under `.sona/prompts` (for all roles) and `.sona/prompts/{role}`
+matching the active role name in lowercase; these files are appended as additional system messages.
 A user-specific system prompt can be edited from the toolbar and is included with every request when set.
 
 Models can also switch roles themselves using a tool that selects a role by name.

--- a/src/test/kotlin/io/qent/sona/prompts/ProjectPromptsTest.kt
+++ b/src/test/kotlin/io/qent/sona/prompts/ProjectPromptsTest.kt
@@ -1,0 +1,38 @@
+package io.qent.sona.prompts
+
+import io.qent.sona.loadProjectPromptMessages
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.file.Files
+
+class ProjectPromptsTest {
+    @Test
+    fun `loads markdown files from user directory`() {
+        val dir = Files.createTempDirectory("sonaPromptsTest")
+        val promptsDir = dir.resolve(".sona").resolve("prompts")
+        Files.createDirectories(promptsDir)
+        Files.writeString(promptsDir.resolve("a.md"), "one")
+        Files.writeString(promptsDir.resolve("b.md"), "two")
+        Files.writeString(promptsDir.resolve("c.txt"), "ignored")
+
+        val messages = loadProjectPromptMessages(dir.toString(), "Architect")
+        assertEquals(2, messages.size)
+    }
+
+    @Test
+    fun `loads role specific markdown files`() {
+        val dir = Files.createTempDirectory("sonaPromptsTest")
+        val promptsDir = dir.resolve(".sona").resolve("prompts")
+        Files.createDirectories(promptsDir)
+        Files.writeString(promptsDir.resolve("a.md"), "one")
+        val roleDir = promptsDir.resolve("architect")
+        Files.createDirectories(roleDir)
+        Files.writeString(roleDir.resolve("b.md"), "two")
+
+        val messages = loadProjectPromptMessages(dir.toString(), "Architect")
+        assertEquals(2, messages.size)
+
+        val other = loadProjectPromptMessages(dir.toString(), "Code")
+        assertEquals(1, other.size)
+    }
+}


### PR DESCRIPTION
## Summary
- read `.md` files from `.sona/prompts` and add them as system prompts
- document user-provided system prompt directory
- test loading prompts from project directory

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a3110c4e808320af85f5d403cfa2de