### PR TITLE
feat: track token usage for all chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,13 @@ data class Chat(
 `StateProvider` operate purely on Kotlin flows without any IntelliJ types.
 
 `tokenUsage` represents the cumulative input, output and cached tokens
-spent for all AI responses in the chat. Each AI message also
-stores its own token usage including cached tokens while user messages
-always record zeros. Providers that do not expose cache statistics
-simply report zero cached tokens. Removing messages does not affect the
-total usage stored for the chat.
+spent for the entire conversation. Every message stored in the chat
+(system, user, tool and AI) records its own token usage. Providers that
+do not expose cache statistics simply report zero cached tokens.
+Removing messages does not affect the total usage stored for the chat.
+Token counts are obtained via a pluggable `TokenCounter` interface that
+can use provider specific implementations such as the official
+Anthropic token counting API.
 
 Repositories for settings and chat history are declared as interfaces in
 `core` so that the UI module can provide IDE specific implementations.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -20,5 +20,8 @@ dependencies {
     implementation(libs.langchain4j.kotlin)
     implementation(libs.langchain4j.anthropic)
     implementation(libs.langchain4j.openai)
+    implementation(libs.langchain4j.google.ai.gemini)
     implementation(libs.langchain4j.mcp)
+    implementation(libs.anthropic.java.core)
+    implementation(libs.anthropic.java.client.okhttp)
 }

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatController.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatController.kt
@@ -3,12 +3,15 @@ package io.qent.sona.core.chat
 import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ToolExecutionResultMessage
 import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.service.TokenStream
 import dev.langchain4j.service.tool.ToolExecution
 import io.qent.sona.core.Logger
+import io.qent.sona.core.model.TokenUsageInfo
 import io.qent.sona.core.model.toInfo
 import io.qent.sona.core.presets.PresetsRepository
 import io.qent.sona.core.settings.SettingsRepository
+import io.qent.sona.core.tokens.TokenCounter
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -30,6 +33,8 @@ class ChatController(
     private val chatStateFlow: ChatStateFlow,
     private val chatAgentFactory: ChatAgentFactory,
     scope: CoroutineScope,
+    private val tokenCounter: TokenCounter,
+    private val systemMessageText: () -> String,
     private val log: Logger = Logger.NoOp,
 ) : ChatSession {
 
@@ -47,13 +52,31 @@ class ChatController(
         log.log("send: chatId=$chatId preset=${preset.model} text=$text")
 
         try {
+            var baseMessages = currentState.messages
+            var totalUsage = currentState.tokenUsage
+
+            if (baseMessages.isEmpty()) {
+                val sysText = systemMessageText()
+                val sysMsg = SystemMessage.from(sysText)
+                val sysTokens = tokenCounter.count(sysText, preset)
+                val sysUsage = TokenUsageInfo(inputTokens = sysTokens)
+                log.log("save system message to repo")
+                chatRepository.addMessage(chatId, sysMsg, preset.model, sysUsage)
+                val sysRepoMsg = ChatRepositoryMessage(chatId, sysMsg, preset.model, sysUsage)
+                baseMessages += sysRepoMsg
+                totalUsage += sysUsage
+            }
+
             val userMsg = UserMessage.from(text)
+            val userTokens = tokenCounter.count(text, preset)
+            val userUsage = TokenUsageInfo(inputTokens = userTokens)
             log.log("save user message to repo")
-            chatRepository.addMessage(chatId, userMsg, preset.model)
-            val userRepoMsg = ChatRepositoryMessage(chatId, userMsg, preset.model)
-            val baseMessages = currentState.messages + userRepoMsg
+            chatRepository.addMessage(chatId, userMsg, preset.model, userUsage)
+            val userRepoMsg = ChatRepositoryMessage(chatId, userMsg, preset.model, userUsage)
+            baseMessages += userRepoMsg
+            totalUsage += userUsage
             log.log("emit: user message")
-            chatStateFlow.emit(currentState.copy(messages = baseMessages))
+            chatStateFlow.emit(currentState.copy(messages = baseMessages, tokenUsage = totalUsage))
 
             val placeholder = ChatRepositoryMessage(chatId, AiMessage.from(""), preset.model)
             log.log("emit: ai placeholder message")
@@ -61,6 +84,7 @@ class ChatController(
                 currentState.copy(
                     requestInProgress = true,
                     messages = baseMessages + placeholder,
+                    tokenUsage = totalUsage,
                     isStreaming = true
                 )
             )
@@ -103,14 +127,15 @@ class ChatController(
                             exec.request().name(),
                             exec.result()
                         )
-
+                        val toolTokens = runBlocking { tokenCounter.count(exec.result(), preset) }
+                        val toolUsage = TokenUsageInfo(inputTokens = toolTokens)
                         runBlocking {
                             log.log("add tool result to repo")
-                            chatRepository.addMessage(chatId, toolResultMessage, preset.model)
+                            chatRepository.addMessage(chatId, toolResultMessage, preset.model, toolUsage)
                         }
 
                         val messages = currentState.messages.toMutableList()
-                        val repositoryMessage = ChatRepositoryMessage(chatId, toolResultMessage, preset.model)
+                        val repositoryMessage = ChatRepositoryMessage(chatId, toolResultMessage, preset.model, toolUsage)
                         val idx = messages.indexOfLast {
                             val m = it.message
                             m is ToolExecutionResultMessage && m.id() == exec.request().id()
@@ -127,8 +152,9 @@ class ChatController(
                         chatStateFlow.emit(
                             currentState.copy(
                                 messages = messages + placeholderAfter,
+                                tokenUsage = currentState.tokenUsage + toolUsage,
                                 requestInProgress = true,
-                                isStreaming = false
+                                isStreaming = true
                             )
                         )
                     }
@@ -139,6 +165,7 @@ class ChatController(
                         }
                         log.log("onCompleteResponse")
                         val totalUsage = response.metadata().tokenUsage().toInfo()
+                        val aiUsage = totalUsage - currentState.tokenUsage
                         val msgs = currentState.messages.toMutableList()
                         val lastIndex = msgs.lastIndex
                         if (lastIndex >= 0) {
@@ -146,18 +173,18 @@ class ChatController(
                                 chatId,
                                 response.aiMessage(),
                                 preset.model,
-                                totalUsage
+                                aiUsage
                             )
                         }
                         runBlocking {
                             log.log("add full response message to repo")
-                            chatRepository.addMessage(chatId, response.aiMessage(), preset.model, totalUsage)
+                            chatRepository.addMessage(chatId, response.aiMessage(), preset.model, aiUsage)
                         }
                         log.log("emit: token usage")
                         chatStateFlow.emit(
                             currentState.copy(
                                 messages = msgs,
-                                tokenUsage = currentState.tokenUsage + totalUsage,
+                                tokenUsage = currentState.tokenUsage + aiUsage,
                                 requestInProgress = false,
                                 isStreaming = false
                             )

--- a/core/src/main/kotlin/io/qent/sona/core/model/TokenUsageInfo.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/model/TokenUsageInfo.kt
@@ -26,6 +26,13 @@ data class TokenUsageInfo(
         cacheCreationInputTokens + other.cacheCreationInputTokens,
         cacheReadInputTokens + other.cacheReadInputTokens,
     )
+
+    operator fun minus(other: TokenUsageInfo) = TokenUsageInfo(
+        outputTokens - other.outputTokens,
+        inputTokens - other.inputTokens,
+        cacheCreationInputTokens - other.cacheCreationInputTokens,
+        cacheReadInputTokens - other.cacheReadInputTokens,
+    )
 }
 
 /** Convert LangChain4j [TokenUsage] to [TokenUsageInfo]. */

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 import io.qent.sona.core.Logger
+import io.qent.sona.core.tokens.DefaultTokenCounter
 
 class StateProvider(
     presetsRepository: PresetsRepository,
@@ -95,6 +96,14 @@ class StateProvider(
         chatRepository,
         connectionErrorText,
     )
+    private val tokenCounter = DefaultTokenCounter()
+    private val systemMessageText = {
+        runBlocking {
+            val roles = rolesRepository.load()
+            val roleText = roles.roles[roles.active].text
+            (systemMessages() + SystemMessage.from(roleText)).joinToString("\n") { it.text() }
+        }
+    }
     private val chatController = ChatController(
         presetsRepository,
         chatRepository,
@@ -102,6 +111,8 @@ class StateProvider(
         chatStateFlow,
         chatAgentFactory,
         scope,
+        tokenCounter,
+        systemMessageText,
         log
     )
 

--- a/core/src/main/kotlin/io/qent/sona/core/tokens/DefaultTokenCounter.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tokens/DefaultTokenCounter.kt
@@ -1,0 +1,43 @@
+package io.qent.sona.core.tokens
+
+import com.anthropic.client.okhttp.AnthropicOkHttpClient
+import com.anthropic.models.messages.MessageCountTokensParams
+import com.anthropic.models.messages.MessageParam
+import com.anthropic.models.messages.Model
+import dev.langchain4j.model.openai.OpenAiTokenCountEstimator
+import dev.langchain4j.model.googleai.GoogleAiGeminiTokenCountEstimator
+import io.qent.sona.core.presets.Preset
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** Token counter backed by langchain4j estimators and provider APIs. */
+class DefaultTokenCounter : TokenCounter {
+    override suspend fun count(text: String, preset: Preset): Int {
+        return when (preset.provider.name) {
+            "Anthropic" -> anthropicCount(text, preset)
+            "Gemini" -> GoogleAiGeminiTokenCountEstimator.builder().modelName(preset.model).build().estimateTokenCountInText(text)
+            else -> OpenAiTokenCountEstimator(preset.model).estimateTokenCountInText(text)
+        }
+    }
+
+    private suspend fun anthropicCount(text: String, preset: Preset): Int = withContext(Dispatchers.IO) {
+        val client = AnthropicOkHttpClient.builder()
+            .apiKey(preset.apiKey)
+            .baseUrl(preset.apiEndpoint)
+            .build()
+        try {
+            val params = MessageCountTokensParams.builder()
+                .model(Model.of(preset.model))
+                .addMessage(
+                    MessageParam.builder()
+                        .role(MessageParam.Role.USER)
+                        .content(text)
+                        .build()
+                )
+                .build()
+            return@withContext client.messages().countTokens(params).inputTokens().toInt()
+        } finally {
+            client.close()
+        }
+    }
+}

--- a/core/src/main/kotlin/io/qent/sona/core/tokens/TokenCounter.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tokens/TokenCounter.kt
@@ -1,0 +1,9 @@
+package io.qent.sona.core.tokens
+
+import io.qent.sona.core.presets.Preset
+
+/** Counts tokens in text for a given model preset. */
+interface TokenCounter {
+    /** Return number of tokens contained in [text] for [preset]. */
+    suspend fun count(text: String, preset: Preset): Int
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ langchain4j_google_ai_gemini = "1.2.0"
 gson = "2.10.1"
 langchain4j_mcp = "1.0.0-beta5"
 langchain4j_http_client_jdk = "1.2.0"
+anthropic_java = "2.5.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -27,6 +28,8 @@ langchain4j-google-ai-gemini = { group = "dev.langchain4j", name = "langchain4j-
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 langchain4j-mcp = { group = "dev.langchain4j", name = "langchain4j-mcp", version.ref = "langchain4j_mcp" }
 langchain4j-http-client-jdk = { group = "dev.langchain4j", name = "langchain4j-http-client-jdk", version.ref = "langchain4j_http_client_jdk" }
+anthropic-java-core = { group = "com.anthropic", name = "anthropic-java-core", version.ref = "anthropic_java" }
+anthropic-java-client-okhttp = { group = "com.anthropic", name = "anthropic-java-client-okhttp", version.ref = "anthropic_java" }
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }


### PR DESCRIPTION
## Summary
- track token counts for system, user, tool and AI messages
- add pluggable TokenCounter with Anthropic token API support
- expose token totals via new counter interface and update docs

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a4a706e24c832086fa83af0015758b