### PR TITLE
Add English response toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - Supported LLM providers and models are defined in `core/src/main/resources/providers.json` so new options can be
   added without modifying the code. A `Custom OpenAI` provider is registered in code for manual model entry and
   always reports zero token cost.
-- Plugin settings contain "Ignore HTTPS errors" and "Enable plugin logging" flags
+- Plugin settings contain "Answer in English", "Ignore HTTPS errors" and "Enable plugin logging" flags
   and an "Anthropic Settings" section to cache system prompts and tool descriptions
   in requests.
 - Plugin settings also provide a global "LLM API retries" field controlling how

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The chat header shows token usage together with the estimated cost for the last
 message and for the entire conversation. It also displays how much of the
 model's context window is currently filled based on the active preset.
 
-The settings screen is split into two sections. **Plugin Settings** contains the
-original **Ignore HTTPS errors** option, an **Enable plugin logging** flag that writes
+The settings screen is split into two sections. **Plugin Settings** contains an **Answer in English** toggle that forces the
+model to respond in English, the original **Ignore HTTPS errors** option, an **Enable plugin logging** flag that writes
 debug messages to the IDE log, and a field for **LLM API retries** that controls how many times failed requests are
 retried with exponential backoff. The new **Anthropic Settings** section adds
 checkboxes to cache system prompts and tool descriptions when sending requests

--- a/core/src/main/kotlin/io/qent/sona/core/settings/Settings.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/settings/Settings.kt
@@ -6,4 +6,5 @@ data class Settings(
     val cacheToolDescriptions: Boolean,
     val apiRetries: Int,
     val enablePluginLogging: Boolean,
+    val answerInEnglish: Boolean,
 )

--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
@@ -68,7 +68,7 @@ private class FakeTools : Tools {
 }
 
 private class FakeSettingsRepository : SettingsRepository {
-    override suspend fun load() = Settings(false, false, false, 0, false)
+    override suspend fun load() = Settings(false, false, false, 0, false, true)
 }
 
 private class EmptyMcpRepository : McpServersRepository {

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -201,9 +201,12 @@ class PluginStateFlow(private val project: Project) : Flow<State>, Disposable {
 
     private fun createSystemMessages(): List<SystemMessage> {
         val env = SystemMessage.from(environmentInfo())
+        val english = if (settingsRepository.state.answerInEnglish) {
+            listOf(SystemMessage.from("Always respond in English, regardless of the request language."))
+        } else emptyList()
         val user = runBlocking { userPromptRepository.load() }
         val userMessages = if (user.isNotBlank()) listOf(SystemMessage.from(user)) else emptyList()
-        return listOf(env) + userMessages + loadPromptMessages()
+        return listOf(env) + english + userMessages + loadPromptMessages()
     }
 
     private fun loadPromptMessages(): List<SystemMessage> {

--- a/src/main/kotlin/io/qent/sona/Strings.kt
+++ b/src/main/kotlin/io/qent/sona/Strings.kt
@@ -51,6 +51,7 @@ object Strings {
     val editConfiguration: String get() = bundle.getString("editConfiguration")
     val pluginSettings: String get() = bundle.getString("pluginSettings")
     val ignoreHttpsErrors: String get() = bundle.getString("ignoreHttpsErrors")
+    val answerInEnglish: String get() = bundle.getString("answerInEnglish")
     val enablePluginLogging: String get() = bundle.getString("enablePluginLogging")
     val anthropicSettings: String get() = bundle.getString("anthropicSettings")
     val cacheSystemPrompts: String get() = bundle.getString("cacheSystemPrompts")

--- a/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
@@ -18,6 +18,7 @@ class PluginSettingsRepository :
         var cacheSystemPrompts: Boolean = true,
         var cacheToolDescriptions: Boolean = true,
         var apiRetries: Int = 0,
+        var answerInEnglish: Boolean = true,
     )
 
     private var pluginSettingsState = PluginSettingsState()
@@ -34,5 +35,6 @@ class PluginSettingsRepository :
         pluginSettingsState.cacheToolDescriptions,
         pluginSettingsState.apiRetries,
         pluginSettingsState.enablePluginLogging,
+        pluginSettingsState.answerInEnglish,
     )
 }

--- a/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
@@ -19,6 +19,7 @@ import org.jetbrains.jewel.ui.component.TextField
 class PluginSettingsConfigurable : Configurable {
 
     private val repo = service<PluginSettingsRepository>()
+    private var currentAnswerInEnglish = repo.state.answerInEnglish
     private var currentIgnoreHttpsErrors = repo.state.ignoreHttpsErrors
     private var currentEnablePluginLogging = repo.state.enablePluginLogging
     private var currentCacheSystemPrompts = repo.state.cacheSystemPrompts
@@ -28,11 +29,13 @@ class PluginSettingsConfigurable : Configurable {
     override fun createComponent() = JewelComposePanel {
         val themeService = service<ThemeService>()
         val dark by themeService.isDark.collectAsState()
+        var answerInEnglish by remember { mutableStateOf(currentAnswerInEnglish) }
         var ignoreHttps by remember { mutableStateOf(currentIgnoreHttpsErrors) }
         var enableLogging by remember { mutableStateOf(currentEnablePluginLogging) }
         var cacheSystemPrompts by remember { mutableStateOf(currentCacheSystemPrompts) }
         var cacheToolDescriptions by remember { mutableStateOf(currentCacheToolDescriptions) }
         val apiRetriesState = rememberTextFieldState(currentApiRetries.toString())
+        LaunchedEffect(answerInEnglish) { currentAnswerInEnglish = answerInEnglish }
         LaunchedEffect(ignoreHttps) { currentIgnoreHttpsErrors = ignoreHttps }
         LaunchedEffect(enableLogging) { currentEnablePluginLogging = enableLogging }
         LaunchedEffect(cacheSystemPrompts) { currentCacheSystemPrompts = cacheSystemPrompts }
@@ -43,6 +46,12 @@ class PluginSettingsConfigurable : Configurable {
         SonaTheme(dark = dark) {
             Column(modifier = Modifier.width(600.dp).padding(16.dp)) {
                 Text(Strings.pluginSettings)
+                Spacer(Modifier.height(8.dp))
+                Row {
+                    Checkbox(checked = answerInEnglish, onCheckedChange = { answerInEnglish = it })
+                    Spacer(Modifier.width(8.dp))
+                      Text(Strings.answerInEnglish)
+                }
                 Spacer(Modifier.height(8.dp))
                 Row {
                     Checkbox(checked = ignoreHttps, onCheckedChange = { ignoreHttps = it })
@@ -81,7 +90,8 @@ class PluginSettingsConfigurable : Configurable {
 
     override fun isModified(): Boolean {
         val saved = repo.state
-        return currentIgnoreHttpsErrors != saved.ignoreHttpsErrors ||
+        return currentAnswerInEnglish != saved.answerInEnglish ||
+            currentIgnoreHttpsErrors != saved.ignoreHttpsErrors ||
             currentEnablePluginLogging != saved.enablePluginLogging ||
             currentCacheSystemPrompts != saved.cacheSystemPrompts ||
             currentCacheToolDescriptions != saved.cacheToolDescriptions ||
@@ -96,6 +106,7 @@ class PluginSettingsConfigurable : Configurable {
                 currentCacheSystemPrompts,
                 currentCacheToolDescriptions,
                 currentApiRetries,
+                currentAnswerInEnglish,
             )
         )
     }

--- a/src/main/resources/messages/Strings.properties
+++ b/src/main/resources/messages/Strings.properties
@@ -41,6 +41,7 @@ installJetBrainsMcpServerPlugin=Install JetBrains MCP Server Plugin
 editConfiguration=Edit configuration
 pluginSettings=Plugin Settings
 ignoreHttpsErrors=Ignore HTTPS errors
+answerInEnglish=Answer in English
 enablePluginLogging=Enable plugin logging
 apiRetries=LLM API retries
 anthropicSettings=Anthropic Settings

--- a/src/main/resources/messages/Strings_de.properties
+++ b/src/main/resources/messages/Strings_de.properties
@@ -41,6 +41,7 @@ installJetBrainsMcpServerPlugin=JetBrains MCP Server Plugin installieren
 editConfiguration=Konfiguration bearbeiten
 pluginSettings=Plugin-Einstellungen
 ignoreHttpsErrors=HTTPS-Fehler ignorieren
+answerInEnglish=Auf Englisch antworten
 enablePluginLogging=Plugin-Protokollierung aktivieren
 apiRetries=Anzahl LLM-API-Wiederholungen
 anthropicSettings=Anthropic-Einstellungen

--- a/src/main/resources/messages/Strings_fr.properties
+++ b/src/main/resources/messages/Strings_fr.properties
@@ -41,6 +41,7 @@ installJetBrainsMcpServerPlugin=Installer le plugin JetBrains MCP Server
 editConfiguration=Modifier la configuration
 pluginSettings=Paramètres du plugin
 ignoreHttpsErrors=Ignorer les erreurs HTTPS
+answerInEnglish=Répondre en anglais
 enablePluginLogging=Activer la journalisation du plugin
 apiRetries=Nombre de tentatives de l'API LLM
 anthropicSettings=Paramètres Anthropic

--- a/src/main/resources/messages/Strings_ru.properties
+++ b/src/main/resources/messages/Strings_ru.properties
@@ -41,6 +41,7 @@ installJetBrainsMcpServerPlugin=Установить плагин JetBrains MCP 
 editConfiguration=Редактировать конфигурацию
 pluginSettings=Настройки плагина
 ignoreHttpsErrors=Игнорировать ошибки HTTPS
+answerInEnglish=Отвечать на английском
 enablePluginLogging=Включить логирование плагина
 apiRetries=Повторы запросов к LLM
 anthropicSettings=Настройки Anthropic

--- a/src/main/resources/messages/Strings_zh.properties
+++ b/src/main/resources/messages/Strings_zh.properties
@@ -41,6 +41,7 @@ installJetBrainsMcpServerPlugin=安装 JetBrains MCP Server 插件
 editConfiguration=编辑配置
 pluginSettings=插件设置
 ignoreHttpsErrors=忽略 HTTPS 错误
+answerInEnglish=用英语回答
 enablePluginLogging=启用插件日志记录
 apiRetries=LLM API 重试次数
 anthropicSettings=Anthropic 设置


### PR DESCRIPTION
## Summary
- add **Answer in English** setting that forces responses in English
- pass the new flag to the system prompt builder
- document English-only option in README and AGENTS

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a4ade29b2c832098386d4f5be113d8