### PR TITLE
Implement provider-specific token counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ spent for the entire conversation. Every message stored in the chat
 do not expose cache statistics simply report zero cached tokens.
 Removing messages does not affect the total usage stored for the chat.
 Token counts are obtained via a pluggable `TokenCounter` interface that
-can use provider specific implementations such as the official
-Anthropic token counting API.
+computes tokens for individual messages using provider specific implementations
+such as the official Anthropic token counting API or langchain4j estimators for
+OpenAI and Gemini models.
 
 Repositories for settings and chat history are declared as interfaces in
 `core` so that the UI module can provide IDE specific implementations.

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatController.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatController.kt
@@ -58,7 +58,7 @@ class ChatController(
             if (baseMessages.isEmpty()) {
                 val sysText = systemMessageText()
                 val sysMsg = SystemMessage.from(sysText)
-                val sysTokens = tokenCounter.count(sysText, preset)
+                val sysTokens = tokenCounter.count(sysMsg, preset)
                 val sysUsage = TokenUsageInfo(inputTokens = sysTokens)
                 log.log("save system message to repo")
                 chatRepository.addMessage(chatId, sysMsg, preset.model, sysUsage)
@@ -68,7 +68,7 @@ class ChatController(
             }
 
             val userMsg = UserMessage.from(text)
-            val userTokens = tokenCounter.count(text, preset)
+            val userTokens = tokenCounter.count(userMsg, preset)
             val userUsage = TokenUsageInfo(inputTokens = userTokens)
             log.log("save user message to repo")
             chatRepository.addMessage(chatId, userMsg, preset.model, userUsage)
@@ -127,7 +127,7 @@ class ChatController(
                             exec.request().name(),
                             exec.result()
                         )
-                        val toolTokens = runBlocking { tokenCounter.count(exec.result(), preset) }
+                        val toolTokens = runBlocking { tokenCounter.count(toolResultMessage, preset) }
                         val toolUsage = TokenUsageInfo(inputTokens = toolTokens)
                         runBlocking {
                             log.log("add tool result to repo")

--- a/core/src/main/kotlin/io/qent/sona/core/tokens/DefaultTokenCounter.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tokens/DefaultTokenCounter.kt
@@ -1,12 +1,70 @@
 package io.qent.sona.core.tokens
 
+import com.anthropic.client.okhttp.AnthropicOkHttpClient
+import com.anthropic.models.messages.MessageCountTokensParams
+import dev.langchain4j.model.googleai.GoogleAiGeminiTokenCountEstimator
+import dev.langchain4j.model.openai.OpenAiTokenCountEstimator
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.ChatMessage
+import dev.langchain4j.data.message.SystemMessage
+import dev.langchain4j.data.message.ToolExecutionResultMessage
+import dev.langchain4j.data.message.UserMessage
 import io.qent.sona.core.presets.Preset
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /** Token counter backed by langchain4j estimators and provider APIs. */
 class DefaultTokenCounter : TokenCounter {
-    override suspend fun count(text: String, preset: Preset): Int {
-        return when (preset.provider.name) {
+    override suspend fun count(message: ChatMessage, preset: Preset): Int =
+        when (preset.provider.name) {
+            "Anthropic" -> countAnthropic(message, preset)
+            "Gemini" -> countGemini(message, preset)
+            "OpenAI" -> countOpenAi(message, preset)
             else -> 0
         }
-    }
+
+    private suspend fun countAnthropic(message: ChatMessage, preset: Preset): Int =
+        withContext(Dispatchers.IO) {
+            val baseUrl = preset.apiEndpoint.substringBefore("/v1")
+            val client = AnthropicOkHttpClient.builder()
+                .apiKey(preset.apiKey)
+                .baseUrl(baseUrl)
+                .build()
+            try {
+                val builder = MessageCountTokensParams.builder().model(preset.model)
+                when (message) {
+                    is SystemMessage -> builder.system(message.text())
+                    is AiMessage -> builder.addAssistantMessage(message.text())
+                    is UserMessage -> builder.addUserMessage(message.singleText())
+                    is ToolExecutionResultMessage -> builder.addUserMessage(message.text())
+                    else -> builder.addUserMessage(message.toString())
+                }
+                client.messages().countTokens(builder.build()).inputTokens().toInt()
+            } catch (e: Exception) {
+                0
+            } finally {
+                client.close()
+            }
+        }
+
+    private suspend fun countGemini(message: ChatMessage, preset: Preset): Int =
+        withContext(Dispatchers.IO) {
+            try {
+                GoogleAiGeminiTokenCountEstimator.builder()
+                    .modelName(preset.model)
+                    .apiKey(preset.apiKey)
+                    .baseUrl(preset.apiEndpoint)
+                    .build()
+                    .estimateTokenCountInMessage(message)
+            } catch (e: Exception) {
+                0
+            }
+        }
+
+    private fun countOpenAi(message: ChatMessage, preset: Preset): Int =
+        try {
+            OpenAiTokenCountEstimator(preset.model).estimateTokenCountInMessage(message)
+        } catch (e: Exception) {
+            0
+        }
 }

--- a/core/src/main/kotlin/io/qent/sona/core/tokens/TokenCounter.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/tokens/TokenCounter.kt
@@ -1,9 +1,10 @@
 package io.qent.sona.core.tokens
 
+import dev.langchain4j.data.message.ChatMessage
 import io.qent.sona.core.presets.Preset
 
-/** Counts tokens in text for a given model preset. */
+/** Counts tokens in messages for a given model preset. */
 interface TokenCounter {
-    /** Return number of tokens contained in [text] for [preset]. */
-    suspend fun count(text: String, preset: Preset): Int
+    /** Return number of tokens contained in [message] for [preset]. */
+    suspend fun count(message: ChatMessage, preset: Preset): Int
 }

--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
@@ -21,6 +21,7 @@ import io.qent.sona.core.data.FileDependenciesInfo
 import io.qent.sona.core.data.SearchResult
 import io.qent.sona.core.tools.Tools
 import io.qent.sona.core.tokens.TokenCounter
+import dev.langchain4j.data.message.ChatMessage
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import org.junit.Assert.assertEquals
@@ -106,7 +107,7 @@ private fun buildChatController(repo: FakeChatRepository): ChatDeps {
     val permissioned = PermissionedToolExecutor(stateFlow, repo)
     val toolsMapFactory = ToolsMapFactory(stateFlow, tools, mcpManager, permissioned, rolesRepo, presetsRepo, settingsRepo)
     val agentFactory = ChatAgentFactory({ throw UnsupportedOperationException() }, { emptyList() }, toolsMapFactory, presetsRepo, rolesRepo, repo, "error")
-    val tokenCounter = object : TokenCounter { override suspend fun count(text: String, preset: Preset) = 0 }
+    val tokenCounter = object : TokenCounter { override suspend fun count(message: ChatMessage, preset: Preset) = 0 }
     val controller = ChatController(presetsRepo, repo, settingsRepo, stateFlow, agentFactory, scope, tokenCounter, { "" })
     return ChatDeps(controller, stateFlow, permissioned, scope, mcpManager)
 }


### PR DESCRIPTION
## Summary
- count tokens for `ChatMessage` instances using provider-specific estimators
- use message objects for system, user, and tool messages in `ChatController`
- document message-based token counting in README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a5c61be5a48320a3ea0f95b7296783