### PR TITLE
Recompute chat context token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ available for manual model entry and is defined directly in code.
 
 The chat header shows token usage together with the estimated cost for the last
 message and for the entire conversation. It also displays how much of the
-model's context window is currently filled based on the active preset.
+model's context window is currently filled by summing tokens across all chat
+messages based on the active preset.
 
 The settings screen is split into two sections. **Plugin Settings** contains an **Answer in English** toggle that forces the
 model to respond in English, the original **Ignore HTTPS errors** option, an **Enable plugin logging** flag that writes
@@ -204,8 +205,9 @@ data class Chat(
 spent for the entire conversation. Every message stored in the chat
 (system, user, tool and AI) records its own token usage. Providers that
 do not expose cache statistics simply report zero cached tokens.
-Removing messages does not affect the total usage stored for the chat.
-Token counts are obtained via a pluggable `TokenCounter` interface that
+Token counts are recomputed from the stored messages, so deleting messages
+adjusts the total usage for the chat. Token counts are obtained via a
+pluggable `TokenCounter` interface that
 computes tokens for individual messages using provider specific implementations
 such as the official Anthropic token counting API or langchain4j estimators for
 OpenAI and Gemini models.

--- a/src/main/kotlin/io/qent/sona/ui/chat/ChatHeader.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/ChatHeader.kt
@@ -32,7 +32,7 @@ fun ChatHeader(state: ChatState) {
     val model = preset?.provider?.models?.find { it.name == preset.model }
     val totalCost = state.totalTokenUsage.cost(model)
     val lastCost = state.lastTokenUsage.cost(model)
-    val contextTokens = state.lastTokenUsage.outputTokens + state.lastTokenUsage.inputTokens
+    val contextTokens = state.totalTokenUsage.outputTokens + state.totalTokenUsage.inputTokens
     val maxContext = model?.maxContextTokens ?: 0
     val rawProgress = if (maxContext > 0) (contextTokens.toFloat() / maxContext.toFloat()).coerceIn(0f, 1f) else 0f
     val progress by animateFloatAsState(targetValue = rawProgress, animationSpec = tween(350), label = "contextProgress")


### PR DESCRIPTION
## Summary
- Recompute chat token usage by summing message TokenUsage values
- Let ChatController defer token total updates to ChatStateFlow
- Base context progress on total token usage

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a603c126f48320bc8f0130a4a67274