### PR TITLE
Add timestamps to UI messages for unique hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
   from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
 - Added translations for Chinese, German and French
 - Global setting to retry failed LLM requests with increasing delay
+- Timestamp added to chat messages to avoid hash collisions between identical texts

--- a/core/src/main/kotlin/io/qent/sona/core/chat/ChatRepository.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/chat/ChatRepository.kt
@@ -48,6 +48,7 @@ data class ChatRepositoryMessage(
     val message: ChatMessage,
     val model: String,
     val tokenUsage: TokenUsageInfo = TokenUsageInfo(),
+    val timestamp: Long = System.currentTimeMillis(),
 )
 
 data class ChatSummary(

--- a/core/src/main/kotlin/io/qent/sona/core/state/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/State.kt
@@ -9,11 +9,18 @@ import io.qent.sona.core.mcp.McpServerStatus
 
 sealed interface UiMessage {
     val text: String
+    val timestamp: Long
 
-    data class User(override val text: String) : UiMessage
-    data class Ai(override val text: String, val toolRequests: List<ToolExecutionRequest>) : UiMessage
+    data class User(override val text: String, override val timestamp: Long) : UiMessage
+    data class Ai(
+        override val text: String,
+        override val timestamp: Long,
+        val toolRequests: List<ToolExecutionRequest>,
+    ) : UiMessage
+
     data class AiMessageWithTools(
         override val text: String,
+        override val timestamp: Long,
         val toolRequests: List<ToolExecutionRequest>,
         val toolResponse: List<String>,
     ) : UiMessage

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateFactory.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateFactory.kt
@@ -43,16 +43,17 @@ class StateFactory {
 
         chat.messages.forEachIndexed { index, message ->
             val m = message.message
+            val ts = if (message.timestamp != 0L) message.timestamp else index.toLong()
 
             val lastUiMessage = uiMessages.lastOrNull()
             val lastUiMessageIndex = uiMessages.size - 1
 
             when (m) {
                 is AiMessage -> {
-                    uiMessages.add(UiMessage.Ai(m.text().orEmpty(), m.toolExecutionRequests()))
+                    uiMessages.add(UiMessage.Ai(m.text().orEmpty(), ts, m.toolExecutionRequests()))
                 }
                 is UserMessage -> {
-                    uiMessages.add(UiMessage.User(m.singleText().trim()))
+                    uiMessages.add(UiMessage.User(m.singleText().trim(), ts))
                 }
                 is ToolExecutionResultMessage -> {
                     when (lastUiMessage) {
@@ -65,12 +66,18 @@ class StateFactory {
                         }
                         is UiMessage.Ai -> {
                             uiMessages[lastUiMessageIndex] = UiMessage.AiMessageWithTools(
-                                lastUiMessage.text, lastUiMessage.toolRequests, listOf(m.text())
+                                lastUiMessage.text,
+                                lastUiMessage.timestamp,
+                                lastUiMessage.toolRequests,
+                                listOf(m.text())
                             )
                         }
                         else -> {
                             uiMessages += UiMessage.AiMessageWithTools(
-                                "", emptyList(), listOf(m.text())
+                                "",
+                                ts,
+                                emptyList(),
+                                listOf(m.text())
                             )
                         }
                     }

--- a/src/main/kotlin/io/qent/sona/repositories/PluginChatRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginChatRepository.kt
@@ -66,6 +66,7 @@ class PluginChatRepository : ChatRepository, PersistentStateComponent<PluginChat
                 cacheCreationInputTokens = cachedOutputTokens,
                 cacheReadInputTokens = cachedInputTokens,
             ),
+            timestamp = timestamp,
         )
     }
 

--- a/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/chat/ChatPanel.kt
@@ -65,6 +65,7 @@ private fun Messages(
     ) {
         itemsIndexed(
             state.messages,
+            key = { _, message -> message.hashCode() }
         ) { index, message ->
             Row(
                 modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary
- add timestamp field to `UiMessage` and repository messages
- ensure missing timestamps fall back to index for backward compatibility
- key chat messages in `ChatPanel` by message hash code

## Testing
- `./gradlew build --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68a61e6665cc8320be013f0e3fb09d5e