### PR TITLE
Use array-based line ranges in search results

### DIFF
--- a/core/src/main/kotlin/io/qent/sona/core/data/FileStructureInfo.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/data/FileStructureInfo.kt
@@ -19,7 +19,7 @@ data class FileElement(
     @Description("Whether the element is public")
     val public: Boolean,
     @Description("Start and end line numbers (1-based)")
-    val lines: Pair<Int, Int>,
+    val lines: List<Int>,
 )
 
 enum class FileElementType {

--- a/core/src/main/resources/prompts/agents/search.md
+++ b/core/src/main/resources/prompts/agents/search.md
@@ -20,30 +20,20 @@ Tools:
 
 Output: only JSON representing `List<SearchResult>` (top-level raw JSON array). No other text, comments, or Markdown (no code fences). Each `SearchResult` object is
 Example (for illustration only; DO NOT include code fences in your output):
-{
-  "files": [
-    {
-      "path": "/abs/path",
-      "elements": [
-        {"name": "MyClass", "type": "CLASS|INTERFACE|OBJECT|ENUM|METHOD|FIELD", "public": true, "lines": [1,10]}
-      ],
-      "lineCount": 123
-    }
-  ],
-  "matchedLines": {"/abs/path": [3,7]}
-}
-{
-  "files": [
-    {
-      "path": "/abs/path",
-      "elements": [
-        {"name": "MyClass", "type": "CLASS|INTERFACE|OBJECT|ENUM|METHOD|FIELD", "public": true, "lines": [1,10]}
-      ],
-      "lineCount": 123
-    }
-  ],
-  "matchedLines": {"/abs/path": [3,7]}
-}
+[
+  {
+    "files": [
+      {
+        "path": "/abs/path",
+        "elements": [
+          {"name": "MyClass", "type": "CLASS|INTERFACE|OBJECT|ENUM|METHOD|FIELD", "public": true, "lines": [1,10]}
+        ],
+        "lineCount": 123
+      }
+    ],
+    "matchedLines": {"/abs/path": [3,7]}
+  }
+]
 
 Output: JSON Schema
 JsonSchema { 
@@ -83,27 +73,11 @@ JsonSchema {
                                         public = JsonBooleanSchema {
                                             description = "Whether the element is public"
                                         }
-                                        lines = JsonObjectSchema {
+                                        lines = JsonArraySchema {
                                             description = "Start and end line numbers (1-based)"
-                                            properties = {
-                                                first = JsonObjectSchema {
-                                                    description = null
-                                                    properties = {}
-                                                    required = []
-                                                    additionalProperties = null
-                                                    definitions = {}
-                                                }
-                                                second = JsonObjectSchema {
-                                                    description = null
-                                                    properties = {}
-                                                    required = []
-                                                    additionalProperties = null
-                                                    definitions = {}
-                                                }
+                                            items = JsonIntegerSchema {
+                                                description = null
                                             }
-                                            required = []
-                                            additionalProperties = null
-                                            definitions = {}
                                         }
                                     }
                                     required = []

--- a/core/src/test/kotlin/io/qent/sona/core/tools/ToolsInfoDecoratorTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/tools/ToolsInfoDecoratorTest.kt
@@ -71,7 +71,7 @@ class ToolsInfoDecoratorTest {
     fun `focused file info passes through permission check`() {
         val repo = StubRepository(listOf(".*"), emptyList())
         val manager = FilePermissionManager(repo)
-        val elem = FileElement("C", FileElementType.CLASS, true, 1 to 2)
+        val elem = FileElement("C", FileElementType.CLASS, true, listOf(1, 2))
         val info = FileStructureInfo("/a", listOf(elem), 10)
         val decorator = ToolsInfoDecorator(testChatStateFlow(), FakeInternalTools(), FakeExternalTools(info, emptyMap()), manager)
         assertEquals(info, decorator.getFocusedFileInfo())

--- a/src/main/kotlin/io/qent/sona/tools/structure/JavaFileStructureProvider.kt
+++ b/src/main/kotlin/io/qent/sona/tools/structure/JavaFileStructureProvider.kt
@@ -40,20 +40,20 @@ class JavaFileStructureProvider : FileStructureProvider {
         val start = document.getLineNumber(aClass.textRange.startOffset) + 1
         val end = document.getLineNumber(aClass.textRange.endOffset) + 1
         val public = aClass.hasModifierProperty(PsiModifier.PUBLIC)
-        elements.add(FileElement(name, type, public, start to end))
+        elements.add(FileElement(name, type, public, listOf(start, end)))
     }
 
     private fun addMethod(method: PsiMethod, document: Document, elements: MutableList<FileElement>) {
         val start = document.getLineNumber(method.textRange.startOffset) + 1
         val end = document.getLineNumber(method.textRange.endOffset) + 1
         val public = method.hasModifierProperty(PsiModifier.PUBLIC)
-        elements.add(FileElement(method.name, FileElementType.METHOD, public, start to end))
+        elements.add(FileElement(method.name, FileElementType.METHOD, public, listOf(start, end)))
     }
 
     private fun addField(field: PsiField, document: Document, elements: MutableList<FileElement>) {
         val start = document.getLineNumber(field.textRange.startOffset) + 1
         val end = document.getLineNumber(field.textRange.endOffset) + 1
         val public = field.hasModifierProperty(PsiModifier.PUBLIC)
-        elements.add(FileElement(field.name, FileElementType.FIELD, public, start to end))
+        elements.add(FileElement(field.name, FileElementType.FIELD, public, listOf(start, end)))
     }
 }

--- a/src/main/kotlin/io/qent/sona/tools/structure/JsFileStructureProviders.kt
+++ b/src/main/kotlin/io/qent/sona/tools/structure/JsFileStructureProviders.kt
@@ -34,21 +34,21 @@ abstract class AbstractJsFileStructureProvider : FileStructureProvider {
                 val name = elem.javaClass.getMethod("getName").invoke(elem) as? String ?: return@forEach
                 val start = document.getLineNumber(elem.textRange.startOffset) + 1
                 val end = document.getLineNumber(elem.textRange.endOffset) + 1
-                elements.add(FileElement(name, FileElementType.CLASS, isPublic(elem), start to end))
+                elements.add(FileElement(name, FileElementType.CLASS, isPublic(elem), listOf(start, end)))
             }
 
             PsiTreeUtil.collectElementsOfType(psiFile, jsFunctionClass).forEach { elem ->
                 val name = elem.javaClass.getMethod("getName").invoke(elem) as? String ?: return@forEach
                 val start = document.getLineNumber(elem.textRange.startOffset) + 1
                 val end = document.getLineNumber(elem.textRange.endOffset) + 1
-                elements.add(FileElement(name, FileElementType.METHOD, isPublic(elem), start to end))
+                elements.add(FileElement(name, FileElementType.METHOD, isPublic(elem), listOf(start, end)))
             }
 
             PsiTreeUtil.collectElementsOfType(psiFile, jsFieldClass).forEach { elem ->
                 val name = elem.javaClass.getMethod("getName").invoke(elem) as? String ?: return@forEach
                 val start = document.getLineNumber(elem.textRange.startOffset) + 1
                 val end = document.getLineNumber(elem.textRange.endOffset) + 1
-                elements.add(FileElement(name, FileElementType.FIELD, isPublic(elem), start to end))
+                elements.add(FileElement(name, FileElementType.FIELD, isPublic(elem), listOf(start, end)))
             }
 
             elements

--- a/src/main/kotlin/io/qent/sona/tools/structure/KotlinFileStructureProvider.kt
+++ b/src/main/kotlin/io/qent/sona/tools/structure/KotlinFileStructureProvider.kt
@@ -35,7 +35,7 @@ class KotlinFileStructureProvider : FileStructureProvider {
             !(modifiers?.hasModifier(KtTokens.PRIVATE_KEYWORD) == true ||
                     modifiers?.hasModifier(KtTokens.PROTECTED_KEYWORD) == true ||
                     modifiers?.hasModifier(KtTokens.INTERNAL_KEYWORD) == true)
-        elements.add(FileElement(name, type, public, start to end))
+        elements.add(FileElement(name, type, public, listOf(start, end)))
         if (decl is KtClassOrObject) {
             decl.declarations.forEach { collectKt(it, document, elements) }
         }

--- a/src/main/kotlin/io/qent/sona/tools/structure/PythonFileStructureProvider.kt
+++ b/src/main/kotlin/io/qent/sona/tools/structure/PythonFileStructureProvider.kt
@@ -23,7 +23,7 @@ class PythonFileStructureProvider : FileStructureProvider {
                 val start = document.getLineNumber(elem.textRange.startOffset) + 1
                 val end = document.getLineNumber(elem.textRange.endOffset) + 1
                 val public = !name.startsWith("_")
-                elements.add(FileElement(name, FileElementType.CLASS, public, start to end))
+                elements.add(FileElement(name, FileElementType.CLASS, public, listOf(start, end)))
             }
 
             PsiTreeUtil.collectElementsOfType(psiFile, pyFunctionClass).forEach { elem ->
@@ -31,7 +31,7 @@ class PythonFileStructureProvider : FileStructureProvider {
                 val start = document.getLineNumber(elem.textRange.startOffset) + 1
                 val end = document.getLineNumber(elem.textRange.endOffset) + 1
                 val public = !name.startsWith("_")
-                elements.add(FileElement(name, FileElementType.METHOD, public, start to end))
+                elements.add(FileElement(name, FileElementType.METHOD, public, listOf(start, end)))
             }
 
             PsiTreeUtil.collectElementsOfType(psiFile, pyTargetClass).forEach { elem ->
@@ -39,7 +39,7 @@ class PythonFileStructureProvider : FileStructureProvider {
                 val start = document.getLineNumber(elem.textRange.startOffset) + 1
                 val end = document.getLineNumber(elem.textRange.endOffset) + 1
                 val public = !name.startsWith("_")
-                elements.add(FileElement(name, FileElementType.FIELD, public, start to end))
+                elements.add(FileElement(name, FileElementType.FIELD, public, listOf(start, end)))
             }
 
             elements


### PR DESCRIPTION
## Summary
- represent file element line ranges as integer arrays
- document line range array in search agent prompt

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a631f6fcc4832083fca6a1b0d6c011