### PR TITLE
Fix MCP tool indicator color updates

### DIFF
--- a/core/src/main/kotlin/io/qent/sona/core/state/State.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/State.kt
@@ -1,7 +1,6 @@
 package io.qent.sona.core.state
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest
-import kotlinx.coroutines.flow.StateFlow
 import io.qent.sona.core.model.TokenUsageInfo
 import io.qent.sona.core.presets.Presets
 import io.qent.sona.core.presets.Preset
@@ -141,7 +140,7 @@ sealed class State {
     }
 
     data class ServersState(
-        val servers: StateFlow<List<McpServerStatus>>,
+        val servers: List<McpServerStatus>,
         val onToggleServer: (String) -> Unit,
         val onToggleTool: (String, String) -> Unit,
         val onReload: () -> Unit,

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateFactory.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateFactory.kt
@@ -12,7 +12,6 @@ import io.qent.sona.core.presets.Presets
 import io.qent.sona.core.roles.Role
 import io.qent.sona.core.roles.Roles
 import io.qent.sona.core.mcp.McpServerStatus
-import kotlinx.coroutines.flow.StateFlow
 
 class StateFactory {
     fun createChatState(
@@ -225,7 +224,7 @@ class StateFactory {
     )
 
     fun createServersState(
-        servers: StateFlow<List<McpServerStatus>>,
+        servers: List<McpServerStatus>,
         onToggleServer: (String) -> Unit,
         onToggleTool: (String, String) -> Unit,
         onReload: () -> Unit,

--- a/src/main/kotlin/io/qent/sona/ui/mcp/ServersPanel.kt
+++ b/src/main/kotlin/io/qent/sona/ui/mcp/ServersPanel.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.key
@@ -40,7 +38,7 @@ import java.net.URI
 
 @Composable
 fun ServersPanel(state: State.ServersState) {
-    val servers by state.servers.collectAsState(emptyList())
+    val servers = state.servers
     val listState = rememberLazyListState()
     Box(
         Modifier


### PR DESCRIPTION
## Summary
- refresh server panel state when MCP server list changes so tool toggles update immediately
- represent server list as a snapshot rather than StateFlow for UI simplicity

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a73b4058b88320bd326d12bb2022ad