### PR TITLE
feat: support per-role configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
   tool request panel and respect user callbacks.
 - The UI passes a list of additional `SystemMessage` values to the core. The first message describes the current
   environment (OS, IDE, Java, Python, Node.js, project root path, file extension statistics, build systems) and is prepended to every LLM request.
-  - Any `.md` files in `src/main/resources/prompts` are bundled. Projects may provide `.md` files in `.sona/prompts` that apply to all roles and in `.sona/prompts/{role}` for role-specific messages; all are appended as additional system messages.
+    - Any `.md` files in `src/main/resources/prompts` are bundled. Projects may provide `.md` files in `.sona/prompts` that apply to all roles and in `.sona/agents/{role}/prompts` for role-specific messages; all are appended as additional system messages.
 - ChatController leverages langchain4j `AiService` and `TokenStream` to emit partial responses and tool events via streaming callbacks.
 - When preparing messages for the `AiService`, append a `ToolExecutionResultMessage` with localized text `Strings.connectionError` after any `AiMessage` that requests a tool but lacks a following result message and persist it to the chat repository.
 - AI messages show a gear icon that toggles visibility of requested tools. Tool outputs stream into a terminal-style bubble with animated dots until completion.
@@ -73,8 +73,8 @@ API while `InternalTools` live in the core module for plugin interactions like
 switching roles. `ToolsInfoDecorator` combines them and routes file responses through a
 permission manager that checks absolute paths against a whitelist (project root by default)
 and a blacklist of sensitive files before exposing file contents to the model.
-File permissions can also be adjusted by adding a `sona.json` file under `.sona` in the project root with
-`permissions.files.whitelist` and `blacklist` arrays of regex patterns.
+  File permissions can also be adjusted by adding a `sona.json` file under `.sona` in the project root or `.sona/agents/{role}` for a specific role with
+  `permissions.files.whitelist` and `blacklist` arrays of regex patterns. Role-specific configuration overrides the main file when present.
 `sona.json` may additionally define an `mcpServers` object keyed by server name with Model
 Context Protocol server configurations including `enabled`, `command`, `args`, environment
 variables, transport, URL, working directory, request headers and an optional
@@ -86,8 +86,8 @@ automatically on restart.
 The plugin preconfigures two servers: `@jetbrains/mcp-proxy` and `memory`. The
 `memory` server runs `@modelcontextprotocol/server-memory` via `npx` and stores
 its data in `.sona/sona_memory.json` inside the project root.
-When updating the configuration, merge new values into `.sona/sona.json` to preserve any
-user-provided fields instead of overwriting the file.
+  When updating the configuration, merge new values into `.sona/sona.json` or `.sona/agents/{role}/sona.json` to preserve any
+  user-provided fields instead of overwriting the file.
 `ChatController` receives a `Tools` decorator from `StateProvider` via its injected `ChatAgentFactory`.
 
 Whenever you extend the logic make sure the flow of state remains unidirectional

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ with every request but is not stored in the chat history. Every request is also
 prefixed with a system message summarizing
 the current environment (OS, IDE, Java, Python, Node.js versions, project root path, file extension
 statistics and build systems). The plugin also reads any `.md` files in `src/main/resources/prompts`.
-Projects can provide their own prompts under `.sona/prompts` (for all roles) and `.sona/prompts/{role}`
+Projects can provide their own prompts under `.sona/prompts` (for all roles) and `.sona/agents/{role}/prompts`
 matching the active role name in lowercase; these files are appended as additional system messages.
 A user-specific system prompt can be edited from the toolbar and is included with every request when set.
 
@@ -107,7 +107,7 @@ you switch to a different chat.
 Tool calls referenced by the model are hidden behind a gear icon in the top‑right corner of each AI message. Clicking the icon reveals the list of requested tools. When a tool starts running, the chat shows a dark terminal‑style bubble with animated dots that are replaced by the tool's output once it finishes.
 If the model message contains only a tool request, the chat displays a note like "Sona is calling tool '<tool>'" instead of an empty response.
 
- The available tools let the model read the focused file, read any file by absolute path and line range, list directory contents, run terminal commands from the project root, read terminal output, apply unified diff patches through `applyPatch`, and switch the active role between Architect and Code. When **Use search agent** is enabled, a dedicated agent can also query the project using tools that search for files, classes and text patterns. Otherwise, the model can call `findFilesByNames`, `findClasses` and `findText` directly through IntelliJ APIs. The search agent runs synchronously and shows tool requests together with their responses in the chat while the final structured answer is not added. Permission prompts from the search agent use the same panel and callbacks as other tool requests. Directory listings append "/" to folder names and include the first-level contents of each directory. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`. Custom lists can be supplied by creating a `sona.json` file inside `.sona` in the project root:
+ The available tools let the model read the focused file, read any file by absolute path and line range, list directory contents, run terminal commands from the project root, read terminal output, apply unified diff patches through `applyPatch`, and switch the active role between Architect and Code. When **Use search agent** is enabled, a dedicated agent can also query the project using tools that search for files, classes and text patterns. Otherwise, the model can call `findFilesByNames`, `findClasses` and `findText` directly through IntelliJ APIs. The search agent runs synchronously and shows tool requests together with their responses in the chat while the final structured answer is not added. Permission prompts from the search agent use the same panel and callbacks as other tool requests. Directory listings append "/" to folder names and include the first-level contents of each directory. File access is guarded by a permission system with a whitelist (project root by default) and a blacklist blocking sensitive files such as `.env`. Custom lists can be supplied by creating a `sona.json` file inside `.sona` in the project root or `.sona/agents/{role}` for a specific role:
 
 ```
 {
@@ -120,7 +120,7 @@ If the model message contains only a tool request, the chat displays a note like
 }
 ```
 
-Sona merges updates into this file to preserve any custom entries the user may have added.
+Sona merges updates into this file to preserve any custom entries the user may have added. Role-specific configuration overrides the main file when present.
 
 The same configuration file can also include an `mcpServers` object keyed by server name specifying Model
 Context Protocol servers. Each entry supports `enabled`, `command`, `args`, `env`, `transport`, `url`, `cwd`
@@ -138,12 +138,12 @@ system messages sent with each request.
 The tool window includes a **Servers** action listing all configured MCP servers. Each server is shown as a card
 with a coloured status indicator – grey for disabled, red when a connection fails, yellow while connecting and
 green once connected and exposing tools. Clicking a card toggles the server on or off. A refresh button above
-the list reloads `.sona/sona.json` and reconnects previously enabled servers. A pinned **Редактировать конфигурацию**
-button at the bottom opens `.sona/sona.json`, creating it with the current server configuration and file permission
-lists when missing. Server enablement is stored in `.sona/sona.json` so only servers marked as enabled start
+the list reloads `.sona/sona.json` or `.sona/agents/{role}/sona.json` depending on the active role and reconnects previously enabled servers. A pinned **Редактировать конфигурацию**
+button at the bottom opens the same file, creating it with the current server configuration and file permission
+lists when missing. Server enablement is stored in this configuration file so only servers marked as enabled start
 automatically after restarting the IDE. Connected servers expand to show their tools with a green indicator next
 to each one. Clicking the indicator disables the tool, turning it grey and excluding it from future LLM requests.
-Disabled tool names persist in `.sona/sona.json` under the server's `disabledTools` array.
+Disabled tool names persist in the same configuration file under the server's `disabledTools` array.
 
 ```json
 {

--- a/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
+++ b/src/main/kotlin/io/qent/sona/PluginStateFlow.kt
@@ -406,13 +406,15 @@ internal fun loadMessagesFromPath(path: Path): List<SystemMessage> {
 }
 
 internal fun loadProjectPromptMessages(basePath: String?, role: String): List<SystemMessage> {
-    val promptsDir = basePath?.let { Paths.get(it, ".sona", "prompts") } ?: return emptyList()
-    if (!Files.isDirectory(promptsDir)) return emptyList()
+    if (basePath == null) return emptyList()
 
     val messages = mutableListOf<SystemMessage>()
-    messages += loadMessagesFromPath(promptsDir)
+    val promptsDir = Paths.get(basePath, ".sona", "prompts")
+    if (Files.isDirectory(promptsDir)) {
+        messages += loadMessagesFromPath(promptsDir)
+    }
 
-    val roleDir = promptsDir.resolve(role.lowercase())
+    val roleDir = Paths.get(basePath, ".sona", "agents", role.lowercase(), "prompts")
     if (Files.isDirectory(roleDir)) {
         messages += loadMessagesFromPath(roleDir)
     }

--- a/src/main/kotlin/io/qent/sona/repositories/PluginFilePermissionsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginFilePermissionsRepository.kt
@@ -1,21 +1,30 @@
 package io.qent.sona.repositories
 
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import io.qent.sona.config.SonaConfig
 import io.qent.sona.core.permissions.FilePermissionsRepository
+import kotlinx.coroutines.runBlocking
 
-class PluginFilePermissionsRepository(project: Project) : FilePermissionsRepository {
+class PluginFilePermissionsRepository(private val project: Project) : FilePermissionsRepository {
 
     override val projectPath = project.basePath ?: "/"
 
-    private val config = SonaConfig.load(projectPath)
+    private fun role(): String = runBlocking {
+        project.service<PluginRolesRepository>().load().let { it.roles[it.active].name }
+    }
 
-    override val whitelist = config?.permissions?.files?.whitelist ?: listOf("$projectPath/.*")
-    override val blacklist = config?.permissions?.files?.blacklist ?: listOf(
-        ".*/\\.env.*",
-        ".*/\\.git.*",
-        ".*/\\.idea/.*",
-        ".*/gradle.properties",
-        ".*/local\\.properties",
-    )
+    private fun config() = SonaConfig.load(projectPath, role())
+
+    override val whitelist: List<String>
+        get() = config()?.permissions?.files?.whitelist ?: listOf("$projectPath/.*")
+
+    override val blacklist: List<String>
+        get() = config()?.permissions?.files?.blacklist ?: listOf(
+            ".*/\\.env.*",
+            ".*/\\.git.*",
+            ".*/\\.idea/.*",
+            ".*/gradle.properties",
+            ".*/local\\.properties",
+        )
 }

--- a/src/test/kotlin/io/qent/sona/config/SonaConfigTest.kt
+++ b/src/test/kotlin/io/qent/sona/config/SonaConfigTest.kt
@@ -27,4 +27,35 @@ class SonaConfigTest {
         assertTrue(json.getAsJsonObject("mcpServers").has("srv"))
         assertTrue(json.getAsJsonObject("permissions").isJsonObject)
     }
+
+    @Test
+    fun `role config overrides main config`() {
+        val dir = Files.createTempDirectory("sonaRoleTest").toFile()
+        val main = File(dir, ".sona/sona.json")
+        main.parentFile.mkdirs()
+        main.writeText("{\"permissions\":{\"files\":{\"whitelist\":[\"main\"]}}}")
+
+        val roleDir = File(dir, ".sona/agents/architect")
+        roleDir.mkdirs()
+        File(roleDir, "sona.json").writeText("{\"permissions\":{\"files\":{\"whitelist\":[\"role\"]}}}")
+
+        val config = SonaConfig.load(dir.absolutePath, "Architect")
+        assertEquals(listOf("role"), config?.permissions?.files?.whitelist)
+    }
+
+    @Test
+    fun `save writes to role config when present`() {
+        val dir = Files.createTempDirectory("sonaRoleSave").toFile()
+        val roleDir = File(dir, ".sona/agents/architect")
+        roleDir.mkdirs()
+        val roleFile = File(roleDir, "sona.json")
+        roleFile.writeText("{}")
+
+        val config = SonaConfig()
+        config.mcpServers = mutableMapOf("srv" to SonaConfig.McpServer().apply { enabled = true })
+
+        SonaConfig.save(dir.absolutePath, config, "Architect")
+
+        assertTrue(roleFile.exists())
+    }
 }

--- a/src/test/kotlin/io/qent/sona/prompts/ProjectPromptsTest.kt
+++ b/src/test/kotlin/io/qent/sona/prompts/ProjectPromptsTest.kt
@@ -25,7 +25,7 @@ class ProjectPromptsTest {
         val promptsDir = dir.resolve(".sona").resolve("prompts")
         Files.createDirectories(promptsDir)
         Files.writeString(promptsDir.resolve("a.md"), "one")
-        val roleDir = promptsDir.resolve("architect")
+        val roleDir = dir.resolve(".sona").resolve("agents").resolve("architect").resolve("prompts")
         Files.createDirectories(roleDir)
         Files.writeString(roleDir.resolve("b.md"), "two")
 


### PR DESCRIPTION
## Summary
- allow role-specific plugin settings and prompts
- load `.sona/agents/{role}` configuration when available
- document new configuration file layout

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a834848dd88320800898f8f52d42ed