### PR TITLE
Add MCP tool execution timeout setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,11 @@
 - Supported LLM providers and models are defined in `core/src/main/resources/providers.json` so new options can be
   added without modifying the code. A `Custom OpenAI` provider is registered in code for manual model entry and
   always reports zero token cost.
-- Plugin settings contain "Answer in English", "Ignore HTTPS errors" and "Enable plugin logging" flags
-  a "Use search agent" toggle and an "Anthropic Settings" section to cache system prompts and
-  tool descriptions in requests.
+- Plugin settings contain "Answer in English", "Ignore HTTPS errors" and "Enable plugin logging" flags,
+    a "Use search agent" toggle, an "MCP tool execution timeout" field and an "Anthropic Settings" section to cache system prompts and
+    tool descriptions in requests.
 - Plugin settings also provide a global "LLM API retries" field controlling how
-  many times failed requests are retried with exponential backoff.
+    many times failed requests are retried with exponential backoff.
 - Each chat tracks tools approved by the user so that previously allowed tools run without asking again.
 - A 🤘 button next to the send action can temporarily auto-approve all tool
   requests in the current chat. The setting resets when switching chats and is

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ messages based on the active preset.
 The settings screen is split into two sections. **Plugin Settings** contains an **Answer in English** toggle that forces the
 model to respond in English, the original **Ignore HTTPS errors** option, an **Enable plugin logging** flag that writes
 debug messages to the IDE log, a **Use search agent** checkbox that delegates project search to a dedicated agent,
-and a field for **LLM API retries** that controls how many times failed requests are
-retried with exponential backoff. The new **Anthropic Settings** section adds
+fields for **LLM API retries**, which controls how many times failed requests are
+retried with exponential backoff, and **MCP tool execution timeout** (default 120 seconds) that limits how long tools may run.
+The new **Anthropic Settings** section adds
 checkboxes to cache system prompts and tool descriptions when sending requests
 to Anthropic models.
 

--- a/core/src/main/kotlin/io/qent/sona/core/mcp/McpConnectionManager.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/mcp/McpConnectionManager.kt
@@ -5,16 +5,19 @@ import dev.langchain4j.mcp.client.McpClient
 import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport
 import io.qent.sona.core.Logger
+import io.qent.sona.core.settings.SettingsRepository
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.io.File
+import java.time.Duration
 import dev.langchain4j.agent.tool.ToolExecutionRequest as AgentToolExecutionRequest
 
 class McpConnectionManager(
     private val repository: McpServersRepository,
     scope: CoroutineScope,
+    private val settingsRepository: SettingsRepository,
     private val log: Logger = Logger.NoOp
 ) {
     private val scope = scope + SupervisorJob() + Dispatchers.IO
@@ -67,8 +70,9 @@ class McpConnectionManager(
             )
         )
         scope.launch {
+            val timeout = settingsRepository.load().mcpToolExecutionTimeout
             runCatching {
-                val client = createClient(config) ?: throw Exception("Invalid config")
+                val client = createClient(config, timeout) ?: throw Exception("Invalid config")
                 val specs = client.listTools()
                 val disabledTools = disabled[config.name] ?: mutableSetOf()
                 synchronized(this@McpConnectionManager) {
@@ -189,7 +193,7 @@ class McpConnectionManager(
     }
 
 
-    private fun createClient(config: McpServerConfig): DefaultMcpClient? {
+    private fun createClient(config: McpServerConfig, toolTimeout: Int): DefaultMcpClient? {
         log.log("Create mcp client for $config")
         config.env?.get("MEMORY_FILE_PATH")?.let { path ->
             runCatching {
@@ -230,6 +234,7 @@ class McpConnectionManager(
         return DefaultMcpClient.Builder()
             .key(config.name)
             .transport(transport)
+            .toolExecutionTimeout(Duration.ofSeconds(toolTimeout.toLong()))
             .build()
     }
 

--- a/core/src/main/kotlin/io/qent/sona/core/settings/Settings.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/settings/Settings.kt
@@ -8,4 +8,5 @@ data class Settings(
     val enablePluginLogging: Boolean,
     val answerInEnglish: Boolean,
     val useSearchAgent: Boolean,
+    val mcpToolExecutionTimeout: Int,
 )

--- a/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
+++ b/core/src/main/kotlin/io/qent/sona/core/state/StateProvider.kt
@@ -120,7 +120,7 @@ class StateProvider(
             }
         }
     }
-    private val mcpManager = McpConnectionManager(mcpServersRepository, scope, log)
+    private val mcpManager = McpConnectionManager(mcpServersRepository, scope, settingsRepository, log)
     private val permissionedToolExecutor = PermissionedToolExecutor(chatStateFlow, chatRepository, log)
     private val toolsMapFactory = ToolsMapFactory(
         chatStateFlow,

--- a/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
+++ b/core/src/test/kotlin/io/qent/sona/core/chat/ChatControllerTest.kt
@@ -75,7 +75,7 @@ private class FakeTools : Tools {
 }
 
 private class FakeSettingsRepository : SettingsRepository {
-    override suspend fun load() = Settings(false, false, false, 0, false, true, false)
+    override suspend fun load() = Settings(false, false, false, 0, false, true, false, 120)
 }
 
 private class EmptyMcpRepository : McpServersRepository {
@@ -101,8 +101,8 @@ private fun buildChatController(repo: FakeChatRepository): ChatDeps {
     val rolesRepo = FakeRolesRepository()
     val tools = FakeTools()
     val scope = CoroutineScope(Dispatchers.Unconfined)
-    val mcpManager = McpConnectionManager(EmptyMcpRepository(), scope)
     val settingsRepo = FakeSettingsRepository()
+    val mcpManager = McpConnectionManager(EmptyMcpRepository(), scope, settingsRepo)
     val stateFlow = ChatStateFlow(repo)
     val permissioned = PermissionedToolExecutor(stateFlow, repo)
     val toolsMapFactory = ToolsMapFactory(stateFlow, tools, mcpManager, permissioned, rolesRepo, presetsRepo, settingsRepo)

--- a/src/main/kotlin/io/qent/sona/Strings.kt
+++ b/src/main/kotlin/io/qent/sona/Strings.kt
@@ -59,6 +59,7 @@ object Strings {
     val cacheSystemPrompts: String get() = bundle.getString("cacheSystemPrompts")
     val cacheToolDescriptions: String get() = bundle.getString("cacheToolDescriptions")
     val apiRetries: String get() = bundle.getString("apiRetries")
+    val mcpToolExecutionTimeout: String get() = bundle.getString("mcpToolExecutionTimeout")
     val openSonaAction: String get() = bundle.getString("openSonaAction")
     val openSonaActionDescription: String get() = bundle.getString("openSonaActionDescription")
     val createAction: String get() = bundle.getString("createAction")

--- a/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
+++ b/src/main/kotlin/io/qent/sona/repositories/PluginSettingsRepository.kt
@@ -20,6 +20,7 @@ class PluginSettingsRepository :
         var apiRetries: Int = 0,
         var answerInEnglish: Boolean = true,
         var useSearchAgent: Boolean = false,
+        var toolExecutionTimeout: Int = 120,
     )
 
     private var pluginSettingsState = PluginSettingsState()
@@ -38,5 +39,6 @@ class PluginSettingsRepository :
         pluginSettingsState.enablePluginLogging,
         pluginSettingsState.answerInEnglish,
         pluginSettingsState.useSearchAgent,
+        pluginSettingsState.toolExecutionTimeout,
     )
 }

--- a/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/io/qent/sona/settings/PluginSettingsConfigurable.kt
@@ -26,6 +26,7 @@ class PluginSettingsConfigurable : Configurable {
     private var currentCacheToolDescriptions = repo.state.cacheToolDescriptions
     private var currentApiRetries = repo.state.apiRetries
     private var currentUseSearchAgent = repo.state.useSearchAgent
+    private var currentToolExecutionTimeout = repo.state.toolExecutionTimeout
 
     override fun createComponent() = JewelComposePanel {
         val themeService = service<ThemeService>()
@@ -36,6 +37,7 @@ class PluginSettingsConfigurable : Configurable {
         var cacheSystemPrompts by remember { mutableStateOf(currentCacheSystemPrompts) }
         var cacheToolDescriptions by remember { mutableStateOf(currentCacheToolDescriptions) }
         var useSearchAgent by remember { mutableStateOf(currentUseSearchAgent) }
+        val toolTimeoutState = rememberTextFieldState(currentToolExecutionTimeout.toString())
         val apiRetriesState = rememberTextFieldState(currentApiRetries.toString())
         LaunchedEffect(answerInEnglish) { currentAnswerInEnglish = answerInEnglish }
         LaunchedEffect(ignoreHttps) { currentIgnoreHttpsErrors = ignoreHttps }
@@ -43,6 +45,9 @@ class PluginSettingsConfigurable : Configurable {
         LaunchedEffect(cacheSystemPrompts) { currentCacheSystemPrompts = cacheSystemPrompts }
         LaunchedEffect(cacheToolDescriptions) { currentCacheToolDescriptions = cacheToolDescriptions }
         LaunchedEffect(useSearchAgent) { currentUseSearchAgent = useSearchAgent }
+        LaunchedEffect(toolTimeoutState.text) {
+            currentToolExecutionTimeout = toolTimeoutState.text.toString().toIntOrNull() ?: 0
+        }
         LaunchedEffect(apiRetriesState.text) {
             currentApiRetries = apiRetriesState.text.toString().toIntOrNull() ?: 0
         }
@@ -79,6 +84,12 @@ class PluginSettingsConfigurable : Configurable {
                     Spacer(Modifier.width(8.dp))
                       Text(Strings.apiRetries)
                 }
+                Spacer(Modifier.height(8.dp))
+                Row {
+                    TextField(toolTimeoutState, Modifier.width(60.dp))
+                    Spacer(Modifier.width(8.dp))
+                      Text(Strings.mcpToolExecutionTimeout)
+                }
                 Spacer(Modifier.height(16.dp))
                 Text(Strings.anthropicSettings)
                 Spacer(Modifier.height(8.dp))
@@ -105,7 +116,8 @@ class PluginSettingsConfigurable : Configurable {
             currentCacheSystemPrompts != saved.cacheSystemPrompts ||
             currentCacheToolDescriptions != saved.cacheToolDescriptions ||
             currentApiRetries != saved.apiRetries ||
-            currentUseSearchAgent != saved.useSearchAgent
+            currentUseSearchAgent != saved.useSearchAgent ||
+            currentToolExecutionTimeout != saved.toolExecutionTimeout
     }
 
     override fun apply() {
@@ -118,6 +130,7 @@ class PluginSettingsConfigurable : Configurable {
                 currentApiRetries,
                 currentAnswerInEnglish,
                 currentUseSearchAgent,
+                currentToolExecutionTimeout,
             )
         )
     }

--- a/src/main/resources/messages/Strings.properties
+++ b/src/main/resources/messages/Strings.properties
@@ -46,6 +46,7 @@ answerInEnglish=Answer in English
 enablePluginLogging=Enable plugin logging
 useSearchAgent=Use search agent
 apiRetries=LLM API retries
+mcpToolExecutionTimeout=MCP tool execution timeout (seconds)
 anthropicSettings=Anthropic Settings
 cacheSystemPrompts=Cache system prompts
 cacheToolDescriptions=Cache tool descriptions

--- a/src/main/resources/messages/Strings_de.properties
+++ b/src/main/resources/messages/Strings_de.properties
@@ -46,6 +46,7 @@ answerInEnglish=Auf Englisch antworten
 enablePluginLogging=Plugin-Protokollierung aktivieren
 useSearchAgent=Suchagent verwenden
 apiRetries=Anzahl LLM-API-Wiederholungen
+mcpToolExecutionTimeout=MCP-Werkzeug-Timeout (Sekunden)
 anthropicSettings=Anthropic-Einstellungen
 cacheSystemPrompts=Systemanweisungen zwischenspeichern
 cacheToolDescriptions=Werkzeugbeschreibungen zwischenspeichern

--- a/src/main/resources/messages/Strings_fr.properties
+++ b/src/main/resources/messages/Strings_fr.properties
@@ -46,6 +46,7 @@ answerInEnglish=Répondre en anglais
 enablePluginLogging=Activer la journalisation du plugin
 useSearchAgent=Utiliser l'agent de recherche
 apiRetries=Nombre de tentatives de l'API LLM
+mcpToolExecutionTimeout=Délai d'exécution des outils MCP (secondes)
 anthropicSettings=Paramètres Anthropic
 cacheSystemPrompts=Mettre en cache les invites système
 cacheToolDescriptions=Mettre en cache les descriptions d’outils

--- a/src/main/resources/messages/Strings_ru.properties
+++ b/src/main/resources/messages/Strings_ru.properties
@@ -46,6 +46,7 @@ answerInEnglish=Отвечать на английском
 enablePluginLogging=Включить логирование плагина
 useSearchAgent=Использовать агента поиска
 apiRetries=Повторы запросов к LLM
+mcpToolExecutionTimeout=Таймаут выполнения инструментов MCP (секунды)
 anthropicSettings=Настройки Anthropic
 cacheSystemPrompts=Кэшировать системные подсказки
 cacheToolDescriptions=Кэшировать описания инструментов

--- a/src/main/resources/messages/Strings_zh.properties
+++ b/src/main/resources/messages/Strings_zh.properties
@@ -46,6 +46,7 @@ answerInEnglish=用英语回答
 enablePluginLogging=启用插件日志记录
 useSearchAgent=使用搜索代理
 apiRetries=LLM API 重试次数
+mcpToolExecutionTimeout=MCP 工具执行超时（秒）
 anthropicSettings=Anthropic 设置
 cacheSystemPrompts=缓存系统提示
 cacheToolDescriptions=缓存工具描述


### PR DESCRIPTION
## Summary
- add MCP tool execution timeout setting with 120s default
- wire timeout into DefaultMcpClient builder
- document new MCP tool timeout option

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68b5b961835c8320a7ebf426ead84542